### PR TITLE
Don't log entire messagecontents on exception

### DIFF
--- a/mautrix_telegram/abstract_user.py
+++ b/mautrix_telegram/abstract_user.py
@@ -198,7 +198,7 @@ class AbstractUser(ABC):
             if not await self.update(update):
                 await self._update(update)
         except Exception:
-            self.log.exception(f"Failed to handle Telegram update {update}")
+            self.log.exception("Failed to handle Telegram update")
             UPDATE_ERRORS.labels(update_type=update_type).inc()
         UPDATE_TIME.labels(update_type=update_type).observe(time.time() - start_time)
 


### PR DESCRIPTION
Even on the Error loglevel, this exception handler was leaking the entire contents of the message.

e.g., 
```
Failed to handle Telegram update UpdateNewChannelMessage(message=Message(id=XXX, peer_id=PeerChannel(channel_id=XXX), date=datetime.datetime(XXX), message='MESSAGE IS HERE', out=False, mentioned=False, media_unread=False, silent=False, post=True, from_scheduled=False, legacy=False, edit_hide=False, pinned=False, from_id=None, fwd_from=None, via_bot_id=None, reply_to=None, ...)
```
