### PR TITLE
example-config: use postgresql: instead of postgres: connection string

### DIFF
--- a/mautrix_telegram/example-config.yaml
+++ b/mautrix_telegram/example-config.yaml
@@ -35,7 +35,7 @@ appservice:
     # Other DBMSes supported by SQLAlchemy may or may not work.
     # Format examples:
     #   SQLite:   sqlite:///filename.db
-    #   Postgres: postgres://username:password@hostname/dbname
+    #   Postgres: postgresql://username:password@hostname/dbname
     database: sqlite:///mautrix-telegram.db
     # Optional extra arguments for SQLAlchemy's create_engine
     database_opts: {}
@@ -251,7 +251,7 @@ bridge:
         #
         # Format examples:
         #   Pickle:   pickle:///filename.pickle
-        #   Postgres: postgres://username:password@hostname/dbname
+        #   Postgres: postgresql://username:password@hostname/dbname
         database: default
         # Options for automatic key sharing.
         key_sharing:


### PR DESCRIPTION
See: https://stackoverflow.com/questions/62688256/sqlalchemy-exc-nosuchmoduleerror-cant-load-plugin-sqlalchemy-dialectspostgre

> SQLAlchemy 1.4 removed the deprecated postgres dialect name, the name postgresql must be used instead now. The dialect is the part before the :// in the URL. SQLAlchemy 1.3 and earlier showed a deprecation warning but still accepted it.