### PR TITLE
Update tgs_converter to match updated lottieconverter

### DIFF
--- a/mautrix_telegram/example-config.yaml
+++ b/mautrix_telegram/example-config.yaml
@@ -223,7 +223,7 @@ bridge:
         # Format to which animated stickers should be converted.
         # disable - No conversion, send as-is (gzipped lottie)
         # png - converts to non-animated png (fastest),
-        # gif - converts to animated gif, but loses transparency
+        # gif - converts to animated gif
         # webm - converts to webm video, requires ffmpeg executable with vp9 codec and webm container support
         target: gif
         # Arguments for converter. All converters take width and height.
@@ -231,8 +231,7 @@ bridge:
         args:
             width: 256
             height: 256
-            background: "020202"  # only for gif
-            fps: 30               # only for webm
+            fps: 25               # only for webm and gif (2, 5, 10, 20, 25 and 50 recommended)
     # End-to-bridge encryption support options. These require matrix-nio to be installed with pip
     # and login_shared_secret to be configured in order to get a device for the bridge bot.
     #

--- a/mautrix_telegram/util/tgs_converter.py
+++ b/mautrix_telegram/util/tgs_converter.py
@@ -64,7 +64,7 @@ if lottieconverter:
             return ConvertedSticker("application/gzip", file)
 
 
-    async def tgs_to_gif(file: bytes, width: int, height: int, fps: int = 30,
+    async def tgs_to_gif(file: bytes, width: int, height: int, fps: int = 25,
                          **_: Any) -> ConvertedSticker:
         proc = await asyncio.create_subprocess_exec(lottieconverter, "-", "-", "gif",
                                                     f"{width}x{height}", str(fps),

--- a/mautrix_telegram/util/tgs_converter.py
+++ b/mautrix_telegram/util/tgs_converter.py
@@ -64,10 +64,10 @@ if lottieconverter:
             return ConvertedSticker("application/gzip", file)
 
 
-    async def tgs_to_gif(file: bytes, width: int, height: int, background: str = "202020",
+    async def tgs_to_gif(file: bytes, width: int, height: int, fps: int = 30,
                          **_: Any) -> ConvertedSticker:
         proc = await asyncio.create_subprocess_exec(lottieconverter, "-", "-", "gif",
-                                                    f"{width}x{height}", f"0x{background}",
+                                                    f"{width}x{height}", str(fps),
                                                     stdout=asyncio.subprocess.PIPE,
                                                     stdin=asyncio.subprocess.PIPE)
         stdout, stderr = await proc.communicate(file)


### PR DESCRIPTION
Hello.

Lottieconverter has been updated (see https://github.com/sot-tech/LottieConverter/pull/3).

* `background` argument is now not used, and conversion will fail, because default "020202" or "202020" are too big (new maximum parameter value for gif is 100);
* Makefile replaced with cmake, so if build/deployment scripts used, they should be updated.

If somebody don't use GIFs or don't need transparency, this release can be ignored.