### PR TITLE
Unpin pillow version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,10 @@ RUN apk add --no-cache \
       bash \
       curl \
       jq \
-      yq
+      yq \
+	  # pillow
+	  libjpeg-turbo-dev \
+	  zlib-dev
 
 COPY requirements.txt /opt/mautrix-telegram/requirements.txt
 COPY optional-requirements.txt /opt/mautrix-telegram/optional-requirements.txt
@@ -54,8 +57,7 @@ RUN apk add --virtual .build-deps \
       libffi-dev \
       build-base \
  && sed -Ei 's/psycopg2-binary.+//' optional-requirements.txt \
- # TODO: unpin Pillow here after it's updated in Alpine
- && pip3 install -r requirements.txt -r optional-requirements.txt 'pillow==8.2' \
+ && pip3 install -r requirements.txt -r optional-requirements.txt \
  && apk del .build-deps
 
 COPY . /opt/mautrix-telegram


### PR DESCRIPTION
To resolve #683, 338a4d9761be565337e19739a953f4be25cccb63 pinned the version of pillow to `8.2` .
This PR removes this pin by adding build dependencies to the Dockerfile (`libjpeg-turbo-dev` and `zlib-dev`)

Feel free to comment on this PR and request changes if needed :)