### PR TITLE
Connect Telegram users after startup lazily to avoid slow startup times

### DIFF
--- a/mautrix_telegram/__main__.py
+++ b/mautrix_telegram/__main__.py
@@ -87,7 +87,15 @@ class TelegramBridge(Bridge):
         init_formatter(context)
         init_portal(context)
         self.add_startup_actions(init_puppet(context))
-        self.add_startup_actions(init_user(context))
+        init_users_task = init_user(context)
+
+        if self.config["telegram.connection.block_startup"] is not False:
+            self.log.info("Connecting users to Telegram before starting up")
+            self.add_startup_actions(init_users_task)
+        else:
+            self.log.info("Connecting users to Telegram in the background")
+            self.loop.create_task(init_users_task)
+
         if self.bot:
             self.add_startup_actions(self.bot.start())
         if self.config["bridge.resend_bridge_info"]:

--- a/mautrix_telegram/__main__.py
+++ b/mautrix_telegram/__main__.py
@@ -13,8 +13,8 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+import asyncio
 from typing import Dict, Any
-
 from telethon import __version__ as __telethon_version__
 from alchemysession import AlchemySessionContainer
 
@@ -55,6 +55,7 @@ class TelegramBridge(Bridge):
     matrix_class = MatrixHandler
 
     config: Config
+    context: Context
     session_container: AlchemySessionContainer
     bot: Bot
 
@@ -65,34 +66,50 @@ class TelegramBridge(Bridge):
             engine=self.db, table_base=Base, session=False,
             table_prefix="telethon_", manage_tables=False)
 
-    def _prepare_website(self, context: Context) -> None:
+    def _prepare_website(self) -> None:
         if self.config["appservice.public.enabled"]:
             public_website = PublicBridgeWebsite(self.loop)
             self.az.app.add_subapp(self.config["appservice.public.prefix"], public_website.app)
-            context.public_website = public_website
+            self.context.public_website = public_website
 
         if self.config["appservice.provisioning.enabled"]:
-            provisioning_api = ProvisioningAPI(context)
+            provisioning_api = ProvisioningAPI(self.context)
             self.az.app.add_subapp(self.config["appservice.provisioning.prefix"],
                                    provisioning_api.app)
-            context.provisioning_api = provisioning_api
+            self.context.provisioning_api = provisioning_api
 
     def prepare_bridge(self) -> None:
         self.bot = init_bot(self.config)
-        context = Context(self.az, self.config, self.loop, self.session_container, self, self.bot)
-        self._prepare_website(context)
-        self.matrix = context.mx = MatrixHandler(context)
+        self.context = Context(self.az, self.config, self.loop, self.session_container, self, self.bot)
+        self._prepare_website()
+        self.matrix = self.context.mx = MatrixHandler(self.context)
 
-        init_abstract_user(context)
-        init_formatter(context)
-        init_portal(context)
-        self.add_startup_actions(init_puppet(context))
-        self.add_startup_actions(init_user(context))
+        init_abstract_user(self.context)
+        init_formatter(self.context)
+        init_portal(self.context)
+        self.add_startup_actions(init_puppet(self.context))
 
         if self.bot:
             self.add_startup_actions(self.bot.start())
         if self.config["bridge.resend_bridge_info"]:
             self.add_startup_actions(self.resend_bridge_info())
+        
+    async def start(self) -> None:
+        await super().start()
+
+        semaphore = None
+        concurrency = self.config['telegram.connection.concurrent_connections_startup']
+        if concurrency:
+            semaphore = asyncio.Semaphore(concurrency)
+            await semaphore.acquire()
+
+        async def sem_task(task):
+            if not semaphore:
+                return await task
+            async with semaphore:
+                return await task
+
+        await asyncio.gather(*(sem_task(task) for task in init_user(self.context)))
 
     async def resend_bridge_info(self) -> None:
         self.config["bridge.resend_bridge_info"] = False

--- a/mautrix_telegram/__main__.py
+++ b/mautrix_telegram/__main__.py
@@ -87,14 +87,7 @@ class TelegramBridge(Bridge):
         init_formatter(context)
         init_portal(context)
         self.add_startup_actions(init_puppet(context))
-        init_users_task = init_user(context)
-
-        if self.config["telegram.connection.block_startup"] is not False:
-            self.log.info("Connecting users to Telegram before starting up")
-            self.add_startup_actions(init_users_task)
-        else:
-            self.log.info("Connecting users to Telegram in the background")
-            self.loop.create_task(init_users_task)
+        self.add_startup_actions(init_user(context))
 
         if self.bot:
             self.add_startup_actions(self.bot.start())

--- a/mautrix_telegram/config.py
+++ b/mautrix_telegram/config.py
@@ -203,6 +203,7 @@ class Config(BaseBridgeConfig):
         copy("telegram.connection.retry_delay")
         copy("telegram.connection.flood_sleep_threshold")
         copy("telegram.connection.request_retries")
+        copy("telegram.connection.block_startup")
 
         copy("telegram.device_info.device_model")
         copy("telegram.device_info.system_version")

--- a/mautrix_telegram/config.py
+++ b/mautrix_telegram/config.py
@@ -203,7 +203,6 @@ class Config(BaseBridgeConfig):
         copy("telegram.connection.retry_delay")
         copy("telegram.connection.flood_sleep_threshold")
         copy("telegram.connection.request_retries")
-        copy("telegram.connection.block_startup")
         copy("telegram.connection.concurrent_connections_startup")
 
         copy("telegram.device_info.device_model")

--- a/mautrix_telegram/config.py
+++ b/mautrix_telegram/config.py
@@ -204,6 +204,7 @@ class Config(BaseBridgeConfig):
         copy("telegram.connection.flood_sleep_threshold")
         copy("telegram.connection.request_retries")
         copy("telegram.connection.block_startup")
+        copy("telegram.connection.concurrent_connections_startup")
 
         copy("telegram.device_info.device_model")
         copy("telegram.device_info.system_version")

--- a/mautrix_telegram/example-config.yaml
+++ b/mautrix_telegram/example-config.yaml
@@ -475,10 +475,6 @@ telegram:
         # is not recommended, since some requests can always trigger a call fail (such as searching
         # for messages).
         request_retries: 5
-        # Should the bridge block startup until all telegram connections have been made for all puppets.
-        # This should be disable for bridges with a large amount of puppets to prevent an extended startup
-        # period. Defaults to true
-        block_startup: true
         # How many concurrent connections should be handled on startup. Set to 0 to allow unlimited connections
         # Defualts to 0
         concurrent_connections_startup: 0

--- a/mautrix_telegram/example-config.yaml
+++ b/mautrix_telegram/example-config.yaml
@@ -475,6 +475,13 @@ telegram:
         # is not recommended, since some requests can always trigger a call fail (such as searching
         # for messages).
         request_retries: 5
+        # Should the bridge block startup until all telegram connections have been made for all puppets.
+        # This should be disable for bridges with a large amount of puppets to prevent an extended startup
+        # period. Defaults to true
+        block_startup: true
+        # How many concurrent connections should be handled on startup. Set to 0 to allow unlimited connections
+        # Defualts to 0
+        concurrent_connections_startup: 0
 
     # Device info sent to Telegram.
     device_info:

--- a/mautrix_telegram/user.py
+++ b/mautrix_telegram/user.py
@@ -54,6 +54,7 @@ SearchResult = NamedTuple('SearchResult', puppet='pu.Puppet', similarity=int)
 
 METRIC_LOGGED_IN = Gauge('bridge_logged_in', 'Users logged into bridge')
 METRIC_CONNECTED = Gauge('bridge_connected', 'Users connected to Telegram')
+METRIC_CONNECTING = Gauge('bridge_connecting', 'Users connecting to Telegram')
 
 BridgeState.human_readable_errors.update({
     "tg-not-connected": "Your Telegram connection failed",
@@ -204,7 +205,11 @@ class User(AbstractUser, BaseUser):
         if not self.puppet_whitelisted or self.connected:
             return self
         async with self._ensure_started_lock:
-            return cast(User, await super().ensure_started(even_if_no_session))
+            try:
+                METRIC_CONNECTING.inc()
+                return cast(User, await super().ensure_started(even_if_no_session))
+            finally:
+                METRIC_CONNECTING.dec()
 
     async def start(self, delete_unless_authenticated: bool = False) -> 'User':
         try:


### PR DESCRIPTION
Fixes #697
Fixes #316

This PR refactors the way connections are made to Telegram slightly which  hopefully doesn't hurt smaller bridges, but actively improves the startup time of larger bridges. Previously, the Telegram bridge would attempt to connect all puppeted users on startup to Telegram and only become "ready" once everyone had been connected (or an attempt had been made). However, this becomes a challenge at scale in the 100s of clients because these connections can each take some time which causes traffic to be delayed and ultimately leads to a worse experience.

This PR instead starts connections to Telegram *after* the bridge has finished it's startup seqeuence. This is also backed by a semaphore to prevent more than N connections to be attempted at once, this is by design as it allows active Matrix users to "jump ahead" in the queue by calling `ensure_started` when handling a Matrix message and therefore get connected before they would usually via the queue.

The semaphore lock is important, as by default all users attempt to connect at once and thus lock in a waiting state until the bridge has connected them. This would mean that calls to ensure_started would fail as a connection would be in progress. 

Thus, this solution hopefully ensures that active users get connected quickly without slowing down traffic processing.

Myself and @tadzik have tested this PR on our side, so we believe it has legs.