### PR TITLE
DROP CONSTRAINT only if exists

### DIFF
--- a/mautrix_telegram/db/upgrade/v01_initial_revision.py
+++ b/mautrix_telegram/db/upgrade/v01_initial_revision.py
@@ -49,7 +49,7 @@ async def migrate_legacy_to_v1(conn: Connection, scheme: str) -> None:
         await conn.execute(
             """
             ALTER TABLE contact
-              DROP CONSTRAINT contact_user_fkey,
+              DROP CONSTRAINT IF EXISTS contact_user_fkey,
               DROP CONSTRAINT contact_contact_fkey,
               ADD CONSTRAINT contact_user_fkey FOREIGN KEY (contact) REFERENCES puppet(id)
                 ON DELETE CASCADE ON UPDATE CASCADE,
@@ -60,14 +60,14 @@ async def migrate_legacy_to_v1(conn: Connection, scheme: str) -> None:
         await conn.execute(
             """
             ALTER TABLE telethon_sessions
-              DROP CONSTRAINT telethon_sessions_pkey,
+              DROP CONSTRAINT IF EXISTS telethon_sessions_pkey,
               ADD CONSTRAINT telethon_sessions_pkey PRIMARY KEY (session_id)
             """
         )
         await conn.execute(
             """
             ALTER TABLE telegram_file
-              DROP CONSTRAINT fk_file_thumbnail,
+              DROP CONSTRAINT IF EXISTS fk_file_thumbnail,
               ADD CONSTRAINT fk_file_thumbnail
                 FOREIGN KEY (thumbnail) REFERENCES telegram_file(id)
                 ON UPDATE CASCADE ON DELETE SET NULL

--- a/mautrix_telegram/db/upgrade/v01_initial_revision.py
+++ b/mautrix_telegram/db/upgrade/v01_initial_revision.py
@@ -60,7 +60,7 @@ async def migrate_legacy_to_v1(conn: Connection, scheme: str) -> None:
         await conn.execute(
             """
             ALTER TABLE telethon_sessions
-              DROP CONSTRAINT IF EXISTS telethon_sessions_pkey,
+              DROP CONSTRAINT telethon_sessions_pkey,
               ADD CONSTRAINT telethon_sessions_pkey PRIMARY KEY (session_id)
             """
         )

--- a/mautrix_telegram/db/upgrade/v01_initial_revision.py
+++ b/mautrix_telegram/db/upgrade/v01_initial_revision.py
@@ -49,7 +49,7 @@ async def migrate_legacy_to_v1(conn: Connection, scheme: str) -> None:
         await conn.execute(
             """
             ALTER TABLE contact
-              DROP CONSTRAINT IF EXISTS contact_user_fkey,
+              DROP CONSTRAINT contact_user_fkey,
               DROP CONSTRAINT contact_contact_fkey,
               ADD CONSTRAINT contact_user_fkey FOREIGN KEY (contact) REFERENCES puppet(id)
                 ON DELETE CASCADE ON UPDATE CASCADE,


### PR DESCRIPTION
Upgrade on postgres from 0.10.2 to 0.11.0 failed due to the following error:

```
mautrix-telegram_1       | [2021-12-29 10:21:20,986] [DEBUG@mau.db.upgrade] Upgrading database from v0 to v1: Initial asyncpg revision
matrix-postgres          | 2021-12-29 10:21:21.022 UTC [221] ERROR:  constraint "fk_file_thumbnail" of relation "telegram_file" does not exist
matrix-postgres          | 2021-12-29 10:21:21.022 UTC [221] STATEMENT:
matrix-postgres          | 	            ALTER TABLE telegram_file
matrix-postgres          | 	              DROP CONSTRAINT fk_file_thumbnail,
matrix-postgres          | 	              ADD CONSTRAINT fk_file_thumbnail
matrix-postgres          | 	                FOREIGN KEY (thumbnail) REFERENCES telegram_file(id)
matrix-postgres          | 	                ON UPDATE CASCADE ON DELETE SET NULL
matrix-postgres          |
mautrix-telegram_1       | [2021-12-29 10:21:21,027] [CRITICAL@mau.db] Failed to upgrade database
mautrix-telegram_1       | Traceback (most recent call last):
mautrix-telegram_1       |   File "/usr/lib/python3.9/site-packages/mautrix/util/async_db/database.py", line 94, in start
mautrix-telegram_1       |     await self.upgrade_table.upgrade(self)
mautrix-telegram_1       |   File "/usr/lib/python3.9/site-packages/mautrix/util/async_db/upgrade.py", line 124, in upgrade
mautrix-telegram_1       |     await upgrade(conn, db.scheme)
mautrix-telegram_1       |   File "/usr/lib/python3.9/site-packages/mautrix_telegram/db/upgrade/v01_initial_revision.py", line 36, in upgrade_v1
mautrix-telegram_1       |     await migrate_legacy_to_v1(conn, scheme)
mautrix-telegram_1       |   File "/usr/lib/python3.9/site-packages/mautrix_telegram/db/upgrade/v01_initial_revision.py", line 67, in migrate_legacy_to_v1
mautrix-telegram_1       |     await conn.execute(
mautrix-telegram_1       |   File "/usr/lib/python3.9/site-packages/asyncpg/connection.py", line 318, in execute
mautrix-telegram_1       |     return await self._protocol.query(query, timeout)
mautrix-telegram_1       |   File "asyncpg/protocol/protocol.pyx", line 338, in query
mautrix-telegram_1       | asyncpg.exceptions.UndefinedObjectError: constraint "fk_file_thumbnail" of relation "telegram_file" does not exist
```

Changing the SQL to `DROP CONSTRAINT IF EXISTS` fixed it for me.