### PR TITLE
Fix DB upgrade to DROP IDENTITY

### DIFF
--- a/mautrix_telegram/db/upgrade/v01_initial_revision.py
+++ b/mautrix_telegram/db/upgrade/v01_initial_revision.py
@@ -75,7 +75,7 @@ async def migrate_legacy_to_v1(conn: Connection, scheme: str) -> None:
         )
         await conn.execute("ALTER TABLE puppet ALTER COLUMN id DROP IDENTITY")
         await conn.execute("DROP SEQUENCE puppet_id_seq")
-        await conn.execute("ALTER TABLE bot_chat ALTER COLUMN id DROP DEFAULT")
+        await conn.execute("ALTER TABLE bot_chat ALTER COLUMN id DROP IDENTITY")
         await conn.execute("DROP SEQUENCE bot_chat_id_seq")
         await conn.execute("ALTER TABLE portal ALTER COLUMN config TYPE jsonb USING config::jsonb")
         await conn.execute(

--- a/mautrix_telegram/db/upgrade/v01_initial_revision.py
+++ b/mautrix_telegram/db/upgrade/v01_initial_revision.py
@@ -73,7 +73,7 @@ async def migrate_legacy_to_v1(conn: Connection, scheme: str) -> None:
                 ON UPDATE CASCADE ON DELETE SET NULL
             """
         )
-        await conn.execute("ALTER TABLE puppet ALTER COLUMN id DROP DEFAULT")
+        await conn.execute("ALTER TABLE puppet ALTER COLUMN id DROP IDENTITY")
         await conn.execute("DROP SEQUENCE puppet_id_seq")
         await conn.execute("ALTER TABLE bot_chat ALTER COLUMN id DROP DEFAULT")
         await conn.execute("DROP SEQUENCE bot_chat_id_seq")


### PR DESCRIPTION
Error I'm seeing when upgrading from 0.10.2 to 0.11.0:

```mautrix-telegram_1       | [2021-12-29 10:27:37,254] [DEBUG@mau.db.upgrade] Upgrading database from v0 to v1: Initial asyncpg revision
matrix-postgres          | 2021-12-29 10:27:37.299 UTC [336] ERROR:  column "id" of relation "puppet" is an identity column
matrix-postgres          | 2021-12-29 10:27:37.299 UTC [336] HINT:  Use ALTER TABLE ... ALTER COLUMN ... DROP IDENTITY instead.
matrix-postgres          | 2021-12-29 10:27:37.299 UTC [336] STATEMENT:  ALTER TABLE puppet ALTER COLUMN id DROP DEFAULT
mautrix-telegram_1       | [2021-12-29 10:27:37,303] [CRITICAL@mau.db] Failed to upgrade database
mautrix-telegram_1       | Traceback (most recent call last):
mautrix-telegram_1       |   File "/usr/lib/python3.9/site-packages/mautrix/util/async_db/database.py", line 94, in start
mautrix-telegram_1       |     await self.upgrade_table.upgrade(self)
mautrix-telegram_1       |   File "/usr/lib/python3.9/site-packages/mautrix/util/async_db/upgrade.py", line 124, in upgrade
mautrix-telegram_1       |     await upgrade(conn, db.scheme)
mautrix-telegram_1       |   File "/usr/lib/python3.9/site-packages/mautrix_telegram/db/upgrade/v01_initial_revision.py", line 36, in upgrade_v1
mautrix-telegram_1       |     await migrate_legacy_to_v1(conn, scheme)
mautrix-telegram_1       |   File "/usr/lib/python3.9/site-packages/mautrix_telegram/db/upgrade/v01_initial_revision.py", line 76, in migrate_legacy_to_v1
mautrix-telegram_1       |     await conn.execute("ALTER TABLE puppet ALTER COLUMN id DROP DEFAULT")
mautrix-telegram_1       |   File "/usr/lib/python3.9/site-packages/asyncpg/connection.py", line 318, in execute
mautrix-telegram_1       |     return await self._protocol.query(query, timeout)
mautrix-telegram_1       |   File "asyncpg/protocol/protocol.pyx", line 338, in query
mautrix-telegram_1       | asyncpg.exceptions.PostgresSyntaxError: column "id" of relation "puppet" is an identity column
mautrix-telegram_1       | HINT:  Use ALTER TABLE ... ALTER COLUMN ... DROP IDENTITY instead.
```

Changing the query to use the hinted query instead.