### PR TITLE
DROP SEQUENCE IF EXISTS

### DIFF
--- a/mautrix_telegram/db/upgrade/v01_initial_revision.py
+++ b/mautrix_telegram/db/upgrade/v01_initial_revision.py
@@ -76,7 +76,7 @@ async def migrate_legacy_to_v1(conn: Connection, scheme: str) -> None:
         await conn.execute("ALTER TABLE puppet ALTER COLUMN id DROP DEFAULT")
         await conn.execute("DROP SEQUENCE IF EXISTS puppet_id_seq")
         await conn.execute("ALTER TABLE bot_chat ALTER COLUMN id DROP DEFAULT")
-        await conn.execute("DROP SEQUENCE bot_chat_id_seq")
+        await conn.execute("DROP SEQUENCE IF EXISTS bot_chat_id_seq")
         await conn.execute("ALTER TABLE portal ALTER COLUMN config TYPE jsonb USING config::jsonb")
         await conn.execute(
             "ALTER TABLE telegram_file ALTER COLUMN decryption_info TYPE jsonb "

--- a/mautrix_telegram/db/upgrade/v01_initial_revision.py
+++ b/mautrix_telegram/db/upgrade/v01_initial_revision.py
@@ -74,7 +74,7 @@ async def migrate_legacy_to_v1(conn: Connection, scheme: str) -> None:
             """
         )
         await conn.execute("ALTER TABLE puppet ALTER COLUMN id DROP DEFAULT")
-        await conn.execute("DROP SEQUENCE puppet_id_seq")
+        await conn.execute("DROP SEQUENCE IF EXISTS puppet_id_seq")
         await conn.execute("ALTER TABLE bot_chat ALTER COLUMN id DROP DEFAULT")
         await conn.execute("DROP SEQUENCE bot_chat_id_seq")
         await conn.execute("ALTER TABLE portal ALTER COLUMN config TYPE jsonb USING config::jsonb")


### PR DESCRIPTION
Getting the following error when upgrading from 0.10.2 to 0.11.0:

```
mautrix-telegram_1       | [2021-12-29 10:31:06,971] [DEBUG@mau.db.upgrade] Upgrading database from v0 to v1: Initial asyncpg revision
matrix-postgres          | 2021-12-29 10:31:07.019 UTC [394] ERROR:  sequence "puppet_id_seq" does not exist
matrix-postgres          | 2021-12-29 10:31:07.019 UTC [394] STATEMENT:  DROP SEQUENCE puppet_id_seq
mautrix-telegram_1       | [2021-12-29 10:31:07,024] [CRITICAL@mau.db] Failed to upgrade database
mautrix-telegram_1       | Traceback (most recent call last):
mautrix-telegram_1       |   File "/usr/lib/python3.9/site-packages/mautrix/util/async_db/database.py", line 94, in start
mautrix-telegram_1       |     await self.upgrade_table.upgrade(self)
mautrix-telegram_1       |   File "/usr/lib/python3.9/site-packages/mautrix/util/async_db/upgrade.py", line 124, in upgrade
mautrix-telegram_1       |     await upgrade(conn, db.scheme)
mautrix-telegram_1       |   File "/usr/lib/python3.9/site-packages/mautrix_telegram/db/upgrade/v01_initial_revision.py", line 36, in upgrade_v1
mautrix-telegram_1       |     await migrate_legacy_to_v1(conn, scheme)
mautrix-telegram_1       |   File "/usr/lib/python3.9/site-packages/mautrix_telegram/db/upgrade/v01_initial_revision.py", line 77, in migrate_legacy_to_v1
mautrix-telegram_1       |     await conn.execute("DROP SEQUENCE puppet_id_seq")
mautrix-telegram_1       |   File "/usr/lib/python3.9/site-packages/asyncpg/connection.py", line 318, in execute
mautrix-telegram_1       |     return await self._protocol.query(query, timeout)
mautrix-telegram_1       |   File "asyncpg/protocol/protocol.pyx", line 338, in query
mautrix-telegram_1       | asyncpg.exceptions.UndefinedTableError: sequence "puppet_id_seq" does not exist
matrix_mautrix-telegram_1 exited with code 25
```

Fixing this to only drop if exists.