### PR TITLE
`BugFix`: Allow users to mention other users in Group Channels again

### DIFF
--- a/mautrix_telegram/formatter/from_matrix/parser.py
+++ b/mautrix_telegram/formatter/from_matrix/parser.py
@@ -59,7 +59,7 @@ class MatrixParser(BaseMatrixParser[TelegramMessage]):
             displayname = user.plain_displayname or msg.text
             msg = TelegramMessage(displayname)
             try:
-                input_entity = self.client.get_input_entity(user.tgid)
+                input_entity = await self.client.get_input_entity(user.tgid)
             except (ValueError, TypeError) as e:
                 log.trace(f"Dropping mention of {user.tgid}: {e}")
             else:


### PR DESCRIPTION
Hi,
I currently can't send messages in group channels when I mention members of the group with '@Name'. 
Matrix shows the message but nothing can be seen in Telegram.

After checking the logs, I've seen the following error:
```
[2021-12-31 02:08:35,001] [WARNING@py.warnings] /usr/lib/python3.9/site-packages/mautrix/util/formatter/parser.py:173: RuntimeWarning: coroutine 'UserMethods.get_input_entity' was never awaited
  custom = await self.custom_node_to_fstring(node, ctx)

[2021-12-31 02:08:35,004] [ERROR@mau.portal..........] Failed to bridge $[.........]: a TLObject was expected but found something else
Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/telethon/tl/tlobject.py", line 194, in __bytes__
    return self._bytes()
  File "/usr/lib/python3.9/site-packages/telethon/tl/functions/messages.py", line 4697, in _bytes
    b'' if self.entities is None or self.entities is False else b''.join((b'\x15\xc4\xb5\x1c',struct.pack('<i', len(self.entities)),b''.join(x._bytes() for x in self.entities))),
  File "/usr/lib/python3.9/site-packages/telethon/tl/functions/messages.py", line 4697, in <genexpr>
    b'' if self.entities is None or self.entities is False else b''.join((b'\x15\xc4\xb5\x1c',struct.pack('<i', len(self.entities)),b''.join(x._bytes() for x in self.entities))),
  File "/usr/lib/python3.9/site-packages/telethon/tl/types/__init__.py", line 9720, in _bytes
    self.user_id._bytes(),
AttributeError: 'coroutine' object has no attribute '_bytes'
```
<details>
More log output:

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/mautrix_telegram/portal.py", line 1690, in handle_matrix_message
    await self._handle_matrix_message(sender, content, event_id)
  File "/usr/lib/python3.9/site-packages/mautrix_telegram/portal.py", line 1744, in _handle_matrix_message
    await self._handle_matrix_text(
  File "/usr/lib/python3.9/site-packages/mautrix_telegram/portal.py", line 1464, in _handle_matrix_text
    response = await client.send_message(
  File "/usr/lib/python3.9/site-packages/telethon/client/messages.py", line 872, in send_message
    result = await self(request)
  File "/usr/lib/python3.9/site-packages/telethon/client/users.py", line 30, in __call__
    return await self._call(self._sender, request, ordered=ordered)
  File "/usr/lib/python3.9/site-packages/telethon/client/users.py", line 63, in _call
    future = sender.send(request, ordered=ordered)
  File "/usr/lib/python3.9/site-packages/telethon/network/mtprotosender.py", line 176, in send
    state = RequestState(request)
  File "/usr/lib/python3.9/site-packages/telethon/network/requeststate.py", line 17, in __init__
    self.data = bytes(request)
  File "/usr/lib/python3.9/site-packages/telethon/tl/tlobject.py", line 200, in __bytes__
    raise TypeError('a TLObject was expected but found something else')
TypeError: a TLObject was expected but found something else
[2021-12-31 02:08:35,024] [WARNING@py.warnings] /usr/lib/python3.9/site-packages/mautrix_telegram/portal.py:1704: RuntimeWarning: coroutine 'UserMethods.get_input_entity' was never awaited
  await self._send_bridge_error(
</details>

I've tested the behavior on version `v0.11.0` and `latest`. 

I think I've found the missing await, therefore I've created this PR (For me the proposed change resolves the issue).
Nevertheless, someone else should also test the change :)