### PR TITLE
Increase `image_as_file_pixels` default value

### DIFF
--- a/mautrix_telegram/example-config.yaml
+++ b/mautrix_telegram/example-config.yaml
@@ -211,8 +211,8 @@ bridge:
     inline_images: false
     # Maximum size of image in megabytes before sending to Telegram as a document.
     image_as_file_size: 10
-    # Maximum number of pixels in an image before sending to Telegram as a document. Defaults to 1280x1280 = 1638400.
-    image_as_file_pixels: 1638400
+    # Maximum number of pixels in an image before sending to Telegram as a document. Defaults to 4096x4096 = 16777216.
+    image_as_file_pixels: 16777216
     # Enable experimental parallel file transfer, which makes uploads/downloads much faster by
     # streaming from/to Matrix and using many connections for Telegram.
     # Note that generating HQ thumbnails for videos is not possible with streamed transfers.


### PR DESCRIPTION
I bumped into a strange issue where some of my sent photos were bridged as file attachments instead of regular photos, even though the image size was well below 10MB (the default limit of this bridge). Turns out there is a second threshold about the image resolution, and it's set to 1280x1280 pixels, while my not-so-flagship Android phone's screenshot resolution is 1080x2400.

I suggest a higher pixel threshold as the default because the current behavior can be confusing for most people when sending screenshots through the bridge. The current 1280x1280 value also has a use case (#552), but I believe the default value shouldn't cause confusion, especially on the recipient side.

Edit: I made some tests, sending the same 1080x2400 screenshot both from Element and the native Android Telegram app. **The file is only downscaled to 1280px when sending with the native Telegram app, so the downscaling problem in #552 shouldn't affect the bridge, that happens in the clients, not on the backend. The same file sent through Element retained its 1080x2400 size, even after downloading it on another device with another Telegram client.**