### PR TITLE
implement handle_puppet_group_invite to auto-create groups

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -54,7 +54,7 @@
   * [x] Automatic portal creation
     * [x] At startup
     * [x] When receiving invite or message
-  * [x] Private chat creation by inviting Matrix puppet of Telegram user to new room
+  * [x] Portal creation by inviting Matrix puppet of Telegram user to new room
   * [x] Option to use bot to relay messages for unauthenticated Matrix users (relaybot)
   * [x] Option to use own Matrix account for messages sent from other Telegram clients (double puppeting)
   * [ ] ‡ Calls (hard, not yet supported by Telethon)

--- a/mautrix_telegram/commands/portal/create_chat.py
+++ b/mautrix_telegram/commands/portal/create_chat.py
@@ -81,4 +81,3 @@ async def create(evt: CommandEvent) -> EventID:
     except ValueError as e:
         await portal.delete()
         return await evt.reply(e.args[0])
-    return await evt.reply(f"Telegram chat created. ID: {portal.tgid}")

--- a/mautrix_telegram/config.py
+++ b/mautrix_telegram/config.py
@@ -130,6 +130,7 @@ class Config(BaseBridgeConfig):
         copy("bridge.sync_direct_chat_list")
         copy("bridge.double_puppet_server_map")
         copy("bridge.double_puppet_allow_discovery")
+        copy("bridge.create_group_on_invite")
         if "bridge.login_shared_secret" in self:
             base["bridge.login_shared_secret_map"] = {
                 base["homeserver.domain"]: self["bridge.login_shared_secret"]

--- a/mautrix_telegram/example-config.yaml
+++ b/mautrix_telegram/example-config.yaml
@@ -312,6 +312,9 @@ bridge:
     kick_on_logout: true
     # Should the "* user joined Telegram" notice always be marked as read automatically?
     always_read_joined_telegram_notice: true
+    # auto-create group chat portals by inviting Matrix puppet of Telegram user to a room
+    # requires double-puppeting to be enabled
+    create_group_on_invite: true
     # Settings for backfilling messages from Telegram.
     backfill:
         # Whether or not the Telegram ghosts of logged in Matrix users should be

--- a/mautrix_telegram/matrix.py
+++ b/mautrix_telegram/matrix.py
@@ -71,6 +71,11 @@ class MatrixHandler(BaseMatrixHandler):
         evt: StateEvent,
         members: list[UserID],
     ) -> None:
+        if not invited_by.is_logged_in:
+            await puppet.default_mxid_intent.leave_room(
+                room_id, reason="You are not logged into this Telegram bridge"
+            )
+            return
         double_puppet = await pu.Puppet.get_by_custom_mxid(invited_by.mxid)
         if not double_puppet or self.az.bot_mxid in members:
             if self.az.bot_mxid not in members:
@@ -91,6 +96,8 @@ class MatrixHandler(BaseMatrixHandler):
             await puppet.default_mxid_intent.leave_room(
                 room_id, reason="You do not have the permissions to bridge this room."
             )
+            return
+        elif not self.config["bridge.create_group_on_invite"]:
             return
 
         await double_puppet.intent.invite_user(room_id, self.az.bot_mxid)

--- a/mautrix_telegram/portal.py
+++ b/mautrix_telegram/portal.py
@@ -555,6 +555,7 @@ class Portal(DBPortal, BasePortal):
             await self.main_intent.set_power_levels(self.mxid, levels)
         await self.handle_matrix_power_levels(source, levels.users, {}, None)
         await self.update_bridge_info()
+        await self.main_intent.send_notice(self.mxid, f"Telegram chat created. ID: {self.tgid}")
 
     async def handle_matrix_invite(
         self, invited_by: u.User, puppet: p.Puppet | au.AbstractUser

--- a/mautrix_telegram/portal_util/power_levels.py
+++ b/mautrix_telegram/portal_util/power_levels.py
@@ -85,7 +85,11 @@ def get_base_power_levels(
         )
     for evt_type, value in overrides.get("events", {}).items():
         levels.events[EventType.find(evt_type)] = value
-    levels.users = overrides.get("users", {})
+    userlevel_overrides = overrides.get("users", {})
+    bot_level = levels.get_user_level(portal.main_intent.mxid)
+    for user, user_level in levels.users.items():
+        if user_level < bot_level:
+            levels.users[user] = userlevel_overrides.get(user, 0)
     if portal.main_intent.mxid not in levels.users:
         levels.users[portal.main_intent.mxid] = 100
     return levels


### PR DESCRIPTION
This PR automatically creates a supergroup if a telegram puppet is invited to a room not marked as DM. This is blocked by the bot already being in the room - in that case we assume that the user wants to use `!tg create`.

The process is as follows
- use double puppet to invite bridge bot and assign power level 100 (if possible)
- create telegram chat more or less how `!tg create` would

This also contains a small fix to `portal_util/power_levels.py` to avoid an error 

Would this require a settings toggle?

I also noticed while using the relay bot to test this that my own messages will be sent via the relay bot until I restart the bridge. `!tg create` produces the same behavior, so this isn't a bug in this PR. I will file an issue.