### PR TITLE
enable delivery receipts in unencrypted rooms

### DIFF
--- a/mautrix_telegram/portal.py
+++ b/mautrix_telegram/portal.py
@@ -1262,12 +1262,7 @@ class Portal(DBPortal, BasePortal):
     async def _send_delivery_receipt(
         self, event_id: EventID, room_id: RoomID | None = None
     ) -> None:
-        # TODO maybe check if the bot is in the room rather than assuming based on self.encrypted
-        if (
-            event_id
-            and self.config["bridge.delivery_receipts"]
-            and (self.encrypted or self.peer_type != "user")
-        ):
+        if event_id and self.config["bridge.delivery_receipts"]:
             try:
                 await self.az.intent.mark_read(room_id or self.mxid, event_id)
             except Exception:


### PR DESCRIPTION
This reverts commit a4595b427d22d4483d6add31b3f2e4816f2dbd1d.

Commit a4595b4 avoids sending delivery receipts to rooms that do not contain the bridge bot.  That was necessary as trying to send a read marker would automatically attempt to join the bridge bot to the room.
That join without invite would fail, hence #483.

But since https://github.com/mautrix/python/commit/f272f16a1d151a1c6612c9349776eda985c8ea3e we no longer attempt to join the sender of read receipts, fixing #483 without necessarily sacrificing the delivery receipt functionality.

See also [mautrix-signal](https://github.com/mautrix/signal/blob/82972ec929f20502da81ec8389b7a3605a9f148d/mautrix_signal/portal.py#L230), which provides delivery receipts without the check removed in this commit.

Thus:
- a4595b4 is no longer necessary, its original purpose is fulfilled by f272f16.
- a4595b4 prevents delivery receipts from working in unencrypted rooms.
- This reverts a4595b4, thus enabling delivery receipts in unencrypted rooms.