### PR TITLE
Add index to puppet custom_mxid column

### DIFF
--- a/mautrix_telegram/db/upgrade/__init__.py
+++ b/mautrix_telegram/db/upgrade/__init__.py
@@ -16,5 +16,5 @@ from . import (
     v11_backfill_queue,
     v12_message_sender,
     v13_multiple_reactions,
-    v14_multiple_reactions,
+    v14_puppet_custom_mxid_index,
 )

--- a/mautrix_telegram/db/upgrade/__init__.py
+++ b/mautrix_telegram/db/upgrade/__init__.py
@@ -16,4 +16,5 @@ from . import (
     v11_backfill_queue,
     v12_message_sender,
     v13_multiple_reactions,
+    v14_multiple_reactions,
 )

--- a/mautrix_telegram/db/upgrade/v14_puppet_custom_mxid_index.py
+++ b/mautrix_telegram/db/upgrade/v14_puppet_custom_mxid_index.py
@@ -1,0 +1,23 @@
+# mautrix-telegram - A Matrix-Telegram puppeting bridge
+# Copyright (C) 2022 Tulir Asokan
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+from mautrix.util.async_db import Connection
+
+from . import upgrade_table
+
+
+@upgrade_table.register(description="Add index to puppet custom_mxid column")
+async def upgrade_v14(conn: Connection) -> None:
+    await conn.execute("CREATE INDEX puppet_custom_mxid_idx ON puppet(custom_mxid)")


### PR DESCRIPTION
We were seeing a huge number of queries for

```sql
SELECT id, is_registered, displayname, displayname_source, displayname_contact, displayname_quality, disable_updates, 
username, phone, photo_id, avatar_url, name_set, avatar_set, is_bot, is_channel, custom_mxid, access_token, next_batch, 
base_url FROM puppet WHERE custom_mxid=$1
```

Which we ended up fixing by adding a unique index. This made our DB CPU graph make a happy face.

![image](https://user-images.githubusercontent.com/2072976/193234269-c58f7115-950f-47fe-9618-553f45d1db0f.png)
