### PR TITLE
Add index to speed up Message.find_recent query

### DIFF
--- a/mautrix_telegram/db/upgrade/__init__.py
+++ b/mautrix_telegram/db/upgrade/__init__.py
@@ -19,4 +19,5 @@ from . import (
     v14_puppet_custom_mxid_index,
     v15_backfill_anchor_id,
     v16_backfill_type,
+    v17_message_find_recent,
 )

--- a/mautrix_telegram/db/upgrade/v00_latest_revision.py
+++ b/mautrix_telegram/db/upgrade/v00_latest_revision.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 from mautrix.util.async_db import Connection, Scheme
 
-latest_version = 16
+latest_version = 17
 
 
 async def create_latest_tables(conn: Connection, scheme: Scheme) -> int:
@@ -73,6 +73,7 @@ async def create_latest_tables(conn: Connection, scheme: Scheme) -> int:
             UNIQUE (mxid, mx_room, tg_space)
         )"""
     )
+    await conn.execute("CREATE INDEX message_mx_room_and_tgid_idx ON message(mx_room, tgid DESC)")
     await conn.execute(
         """CREATE TABLE reaction (
             mxid      TEXT NOT NULL,

--- a/mautrix_telegram/db/upgrade/v14_puppet_custom_mxid_index.py
+++ b/mautrix_telegram/db/upgrade/v14_puppet_custom_mxid_index.py
@@ -20,4 +20,4 @@ from . import upgrade_table
 
 @upgrade_table.register(description="Add index to puppet custom_mxid column")
 async def upgrade_v14(conn: Connection) -> None:
-    await conn.execute("CREATE INDEX puppet_custom_mxid_idx ON puppet(custom_mxid)")
+    await conn.execute("CREATE INDEX IF NOT EXISTS puppet_custom_mxid_idx ON puppet(custom_mxid)")

--- a/mautrix_telegram/db/upgrade/v17_message_find_recent.py
+++ b/mautrix_telegram/db/upgrade/v17_message_find_recent.py
@@ -21,5 +21,5 @@ from . import upgrade_table
 @upgrade_table.register(description="Add index for Message.find_recent")
 async def upgrade_v17(conn: Connection) -> None:
     await conn.execute(
-        "CREATE INDEX message_mx_room_and_tgid_idx ON message(mx_room, tgid DESC)"
+        "CREATE INDEX IF NOT EXISTS message_mx_room_and_tgid_idx ON message(mx_room, tgid DESC)"
     )

--- a/mautrix_telegram/db/upgrade/v17_message_find_recent.py
+++ b/mautrix_telegram/db/upgrade/v17_message_find_recent.py
@@ -1,0 +1,25 @@
+# mautrix-telegram - A Matrix-Telegram puppeting bridge
+# Copyright (C) 2022 Tulir Asokan
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+from mautrix.util.async_db import Connection
+
+from . import upgrade_table
+
+
+@upgrade_table.register(description="Add index for Message.find_recent")
+async def upgrade_v17(conn: Connection) -> None:
+    await conn.execute(
+        "CREATE INDEX message_mx_room_and_tgid_idx ON message(mx_room, tgid DESC)"
+    )


### PR DESCRIPTION
This optimizes the heavy query made by Message.find_recent added by 026c39a in v0.12.1:
```sql
SELECT mxid, mx_room, tgid, tg_space, edit_index, redacted, content_hash, sender_mxid, sender FROM message
WHERE mx_room=$1 AND sender<>$2
ORDER BY tgid DESC LIMIT $3
```

Similar to #845, this was needed to unblock overloading our RDS on long queries.  Here's a chart of the DB load 1) before upgrading to v0.12.1, 2) after upgrading, and 3) after adding the index (and killing hung leftover queries).
![image](https://user-images.githubusercontent.com/3271094/199097918-9279a793-9663-42e4-85c8-8bf0d66e49e9.png)
