### PR TITLE
Update asyncpg

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ yarl>=1,<2
 mautrix>=0.18.6,<0.19
 #telethon>=1.25.4,<1.26
 tulir-telethon==1.26.0a10
-asyncpg>=0.20,<0.27
+asyncpg>=0.20,<0.28
 mako>=1,<2
 setuptools


### PR DESCRIPTION
A new version of asyncpg was released: https://github.com/MagicStack/asyncpg/releases/tag/v0.27.0
mautrix-telegram is packaged in Nixpkgs. asyncpg was updated in https://github.com/NixOS/nixpkgs/pull/199918. This asyncpg version is now incompatible with mautrix-telegram.
Adding the change to `requirements.txt` here is nicer than adding a patch to Nixpkgs.
Note that I have not yet tested that there are no regressions with this new version.