### PR TITLE
Change the wording of the "no tg bot" error message

### DIFF
--- a/mautrix_telegram/matrix.py
+++ b/mautrix_telegram/matrix.py
@@ -186,7 +186,7 @@ class MatrixHandler(BaseMatrixHandler):
             await portal.main_intent.kick_user(
                 room_id,
                 user.mxid,
-                "This chat does not have a bot relaying messages for unauthenticated users.",
+                "The Telegram side of this portal does not have a bot relaying messages to Matrix for unauthenticated users.",
             )
             return
 


### PR DESCRIPTION
The previous wording was not clear and left me confused on multiple separate occasions. I always thought something is wrong on the Matrix side. I hope this wording makes it a little bit more clear