### PR TITLE
Add portal to cache also when creating a portal from the matrix side

### DIFF
--- a/mautrix_telegram/commands/portal/create_chat.py
+++ b/mautrix_telegram/commands/portal/create_chat.py
@@ -65,19 +65,11 @@ async def create(evt: CommandEvent) -> EventID:
         about=about,
         encrypted=encrypted,
     )
-    invites, errors = await portal.get_telegram_users_in_matrix_room(evt.sender, pre_create=True)
-    if len(errors) > 0:
-        error_list = "\n".join(f"* [{mxid}](https://matrix.to/#/{mxid})" for mxid in errors)
-        await evt.reply(
-            f"Failed to add the following users to the chat:\n\n{error_list}\n\n"
-            "You can try `$cmdprefix+sp search -r <username>` to help the bridge find "
-            "those users."
-        )
 
     await warn_missing_power(levels, evt)
 
     try:
-        await portal.create_telegram_chat(evt.sender, invites=invites, supergroup=supergroup)
+        await portal.create_telegram_chat(evt.sender, supergroup=supergroup)
     except ValueError as e:
         await portal.delete()
         return await evt.reply(e.args[0])

--- a/mautrix_telegram/matrix.py
+++ b/mautrix_telegram/matrix.py
@@ -135,20 +135,8 @@ class MatrixHandler(BaseMatrixHandler):
             levels.users[self.az.bot_mxid] = 100 if invited_by_level >= 100 else invited_by_level
             await double_puppet.intent.set_power_levels(room_id, levels)
 
-        invites, errors = await portal.get_telegram_users_in_matrix_room(
-            invited_by, pre_create=True
-        )
-        if len(errors) > 0:
-            error_list = "\n".join(f"* [{mxid}](https://matrix.to/#/{mxid})" for mxid in errors)
-            await portal.az.intent.send_notice(
-                room_id,
-                f"Failed to add the following users to the chat:\n\n{error_list}\n\n"
-                "You can try `$cmdprefix+sp search -r <username>` to help the bridge find "
-                "those users.",
-            )
-
         try:
-            await portal.create_telegram_chat(invited_by, invites=invites, supergroup=True)
+            await portal.create_telegram_chat(invited_by, supergroup=True)
         except ValueError as e:
             await portal.delete()
             await portal.az.intent.send_notice(room_id, e.args[0])

--- a/mautrix_telegram/portal.py
+++ b/mautrix_telegram/portal.py
@@ -186,7 +186,7 @@ from mautrix.types import (
     UserID,
     VideoInfo,
 )
-from mautrix.util import background_task, magic, variation_selector
+from mautrix.util import background_task, magic, markdown, variation_selector
 from mautrix.util.format_duration import format_duration
 from mautrix.util.message_send_checkpoint import MessageSendCheckpointStatus
 from mautrix.util.simple_lock import SimpleLock
@@ -566,11 +566,14 @@ class Portal(DBPortal, BasePortal):
         )
         if len(errors) > 0:
             error_list = "\n".join(f"* [{mxid}](https://matrix.to/#/{mxid})" for mxid in errors)
+            command_prefix = self.config["bridge.command_prefix"]
             await self.az.intent.send_notice(
                 self.mxid,
-                f"Failed to add the following users to the chat:\n\n{error_list}\n\n"
-                "You can try `$cmdprefix+sp search -r <username>` to help the bridge find "
-                "those users.",
+                markdown.render(
+                    f"Failed to add the following users to the chat:\n\n{error_list}\n\n"
+                    f"You can try `{command_prefix} search -r <username>` to help the bridge find "
+                    "those users."
+                ),
             )
         elif self.tgid:
             raise ValueError("Can't create Telegram chat for portal with existing Telegram chat.")

--- a/mautrix_telegram/portal.py
+++ b/mautrix_telegram/portal.py
@@ -567,13 +567,13 @@ class Portal(DBPortal, BasePortal):
         if len(errors) > 0:
             error_list = "\n".join(f"* [{mxid}](https://matrix.to/#/{mxid})" for mxid in errors)
             command_prefix = self.config["bridge.command_prefix"]
+            message = (
+                f"Failed to add the following users to the chat:\n\n{error_list}\n\n"
+                f"You can try `{command_prefix} search -r <username>` to help the bridge find "
+                "those users."
+            )
             await self.az.intent.send_notice(
-                self.mxid,
-                markdown.render(
-                    f"Failed to add the following users to the chat:\n\n{error_list}\n\n"
-                    f"You can try `{command_prefix} search -r <username>` to help the bridge find "
-                    "those users."
-                ),
+                self.mxid, text=message, html=markdown.render(message)
             )
         elif self.tgid:
             raise ValueError("Can't create Telegram chat for portal with existing Telegram chat.")


### PR DESCRIPTION
Fixes #367 

I also moved the call to `get_telegram_users_from_matrix_room()` to `create_telegram_chat()` to reduce code doubling and parameters passed to the latter function, because I had to touch that part anyway. I didn't see a good reason not to.