### PR TITLE
Bridge files as links

### DIFF
--- a/mautrix_telegram/config.py
+++ b/mautrix_telegram/config.py
@@ -136,6 +136,8 @@ class Config(BaseBridgeConfig):
         copy("bridge.caption_in_message")
         copy("bridge.image_as_file_size")
         copy("bridge.image_as_file_pixels")
+        copy("bridge.document_as_link_size.bot")
+        copy("bridge.document_as_link_size.channel")
         copy("bridge.parallel_file_transfer")
         copy("bridge.federate_rooms")
         copy("bridge.always_custom_emoji_reaction")

--- a/mautrix_telegram/example-config.yaml
+++ b/mautrix_telegram/example-config.yaml
@@ -222,6 +222,11 @@ bridge:
     image_as_file_size: 10
     # Maximum number of pixels in an image before sending to Telegram as a document. Defaults to 4096x4096 = 16777216.
     image_as_file_pixels: 16777216
+    # Maximum size of Telegram documents before linking to Telegrm instead of bridge
+    # to Matrix media.
+    document_as_link_size:
+        channel:
+        bot:
     # Enable experimental parallel file transfer, which makes uploads/downloads much faster by
     # streaming from/to Matrix and using many connections for Telegram.
     # Note that generating HQ thumbnails for videos is not possible with streamed transfers.

--- a/mautrix_telegram/portal.py
+++ b/mautrix_telegram/portal.py
@@ -445,6 +445,10 @@ class Portal(DBPortal, BasePortal):
         return self.peer_type == "user"
 
     @property
+    def is_channel(self) -> bool:
+        return self.peer_type == "channel"
+
+    @property
     def has_bot(self) -> bool:
         return bool(self.bot) and (
             self.bot.is_in_chat(self.tgid)
@@ -2809,7 +2813,7 @@ class Portal(DBPortal, BasePortal):
         intent = sender.intent_for(self) if sender else self.main_intent
         is_bot = sender.is_bot if sender else False
         converted = await self._msg_conv.convert(
-            source, intent, is_bot, evt, no_reply_fallback=True
+            source, intent, is_bot, self.is_channel, evt, no_reply_fallback=True
         )
         converted.content.set_edit(editing_msg.mxid)
         await intent.set_typing(self.mxid, timeout=0)
@@ -3025,6 +3029,7 @@ class Portal(DBPortal, BasePortal):
             source,
             intent,
             is_bot,
+            self.is_channel,
             msg,
             client=client,
             deterministic_reply_id=self.bridge.homeserver_software.is_hungry,
@@ -3529,7 +3534,7 @@ class Portal(DBPortal, BasePortal):
         else:
             intent = self.main_intent
         is_bot = sender.is_bot if sender else False
-        converted = await self._msg_conv.convert(source, intent, is_bot, evt)
+        converted = await self._msg_conv.convert(source, intent, is_bot, self.is_channel, evt)
         if not converted:
             return
         await intent.set_typing(self.mxid, timeout=0)

--- a/mautrix_telegram/portal_util/message_convert.py
+++ b/mautrix_telegram/portal_util/message_convert.py
@@ -161,6 +161,7 @@ class TelegramMessageConverter:
         source: au.AbstractUser,
         intent: IntentAPI,
         is_bot: bool,
+        is_channel: bool,
         evt: Message,
         no_reply_fallback: bool = False,
         deterministic_reply_id: bool = False,

--- a/mautrix_telegram/util/__init__.py
+++ b/mautrix_telegram/util/__init__.py
@@ -4,6 +4,7 @@ from .file_transfer import (
     convert_image,
     transfer_custom_emojis_to_matrix,
     transfer_file_to_matrix,
+    transfer_thumbnail_to_matrix,
     unicode_custom_emoji_map,
 )
 from .parallel_file_transfer import parallel_transfer_to_telegram


### PR DESCRIPTION
Adds two new optional configs to prevent bridging of media over certain sizes from bots/channels.