### PR TITLE
optionally disable converting "!"-prefixed commands to "/"-prefixed commands

### DIFF
--- a/mautrix_telegram/config.py
+++ b/mautrix_telegram/config.py
@@ -217,6 +217,7 @@ class Config(BaseBridgeConfig):
             del self["bridge.message_formats"]
         copy_dict("bridge.message_formats", override_existing_map=False)
         copy("bridge.emote_format")
+        copy("bridge.convert_commands")
         copy("bridge.relay_user_distinguishers")
 
         copy("bridge.state_event_formats.join")

--- a/mautrix_telegram/example-config.yaml
+++ b/mautrix_telegram/example-config.yaml
@@ -475,7 +475,8 @@ bridge:
     #    $username    - Telegram username (may not exist)
     #    $mention     - Telegram @username or displayname mention (depending on which exists)
     emote_format: "* $mention $formatted_body"
-
+    # Replace ! with / to send telegram bot commands without interfering with matrix client commands
+    convert_commands: true
     # The formats to use when sending state events to Telegram via the relay bot.
     #
     # Variables from `message_formats` that have the `sender_` prefix are available without the prefix.

--- a/mautrix_telegram/formatter/from_matrix/__init__.py
+++ b/mautrix_telegram/formatter/from_matrix/__init__.py
@@ -54,21 +54,26 @@ async def matrix_reply_to_telegram(
 
 
 async def matrix_to_telegram(
-    client: TelegramClient, *, text: str | None = None, html: str | None = None
+    client: TelegramClient,
+    *,
+    text: str | None = None,
+    html: str | None = None,
+    convert_commands: bool = True,
 ) -> tuple[str, list[TypeMessageEntity]]:
     if html is not None:
-        return await _matrix_html_to_telegram(client, html)
+        return await _matrix_html_to_telegram(client, html, convert_commands)
     elif text is not None:
-        return _matrix_text_to_telegram(text)
+        return _matrix_text_to_telegram(text, convert_commands)
     else:
         raise ValueError("text or html must be provided to convert formatting")
 
 
 async def _matrix_html_to_telegram(
-    client: TelegramClient, html: str
+    client: TelegramClient, html: str, convert_commands: bool
 ) -> tuple[str, list[TypeMessageEntity]]:
     try:
-        html = command_regex.sub(r"<command>\1</command>", html)
+        if convert_commands:
+            html = command_regex.sub(r"<command>\1</command>", html)
         html = html.replace("\t", " " * 4)
         html = not_command_regex.sub(r"\1", html)
 
@@ -98,8 +103,11 @@ def _cut_long_message(
     return message, entities
 
 
-def _matrix_text_to_telegram(text: str) -> tuple[str, list[TypeMessageEntity]]:
-    text = command_regex.sub(r"/\1", text)
+def _matrix_text_to_telegram(
+    text: str, convert_commands: bool
+) -> tuple[str, list[TypeMessageEntity]]:
+    if convert_commands:
+        text = command_regex.sub(r"/\1", text)
     text = text.replace("\t", " " * 4)
     text = not_command_regex.sub(r"\1", text)
     entities = []

--- a/mautrix_telegram/portal.py
+++ b/mautrix_telegram/portal.py
@@ -1503,7 +1503,11 @@ class Portal(DBPortal, BasePortal):
             message = await self._get_state_change_message(event, user, **kwargs)
             if not message:
                 return
-            message, entities = await formatter.matrix_to_telegram(self.bot.client, html=message)
+            message, entities = await formatter.matrix_to_telegram(
+                self.bot.client,
+                html=message,
+                convert_commands=self.config["bridge.convert_commands"],
+            )
             response = await self.bot.client.send_message(
                 self.peer, message, formatting_entities=entities
             )
@@ -1789,7 +1793,10 @@ class Portal(DBPortal, BasePortal):
         reply_to: TelegramID | None,
     ) -> None:
         message, entities = await formatter.matrix_to_telegram(
-            client, text=content.body, html=content.formatted(Format.HTML)
+            client,
+            text=content.body,
+            html=content.formatted(Format.HTML),
+            convert_commands=self.config["bridge.convert_commands"],
         )
         sender_id = sender.tgid if logged_in else self.bot.tgid
         async with self.send_lock(sender_id):
@@ -1933,7 +1940,10 @@ class Portal(DBPortal, BasePortal):
 
         capt, entities = (
             await formatter.matrix_to_telegram(
-                client, text=caption.body, html=caption.formatted(Format.HTML)
+                client,
+                text=caption.body,
+                html=caption.formatted(Format.HTML),
+                convert_commands=self.config["bridge.convert_commands"],
             )
             if caption
             else (None, None)
@@ -2030,7 +2040,9 @@ class Portal(DBPortal, BasePortal):
             caption = content["org.matrix.msc3488.location"]["description"]
             entities = []
         except KeyError:
-            caption, entities = await formatter.matrix_to_telegram(client, text=content.body)
+            caption, entities = await formatter.matrix_to_telegram(
+                client, text=content.body, convert_commands=self.config["bridge.convert_commands"]
+            )
         media = MessageMediaGeo(geo=GeoPoint(lat=lat, long=long, access_hash=0))
 
         async with self.send_lock(sender_id):


### PR DESCRIPTION
When sending a "!"-prefixed matrix command, it gets converted to a "/"-prefixed telegram command. This may be handy at times, but it can also be confusing.

I have a group that's bridged between matrix, signal and telegram. There is a matrix bot in the room that anyone can interact with. It's confusing for telegram users that matrix users can seemingly use the forward slash prefix while they have to use the exclamation mark prefix.

This PR allows disabling that conversion and bridges commands unchanged, thus avoiding confusion.

I suppose an alternative would be to instead convert /telegram commands into !matrix commands so that what telegram users see is consistent.

Not sure if this is something you'd like, just let me know.