### PR TITLE
Add periodic connection refresh

### DIFF
--- a/mautrix_telegram/abstract_user.py
+++ b/mautrix_telegram/abstract_user.py
@@ -248,7 +248,11 @@ class AbstractUser(ABC):
         if not reconnect_interval or reconnect_interval == 0:
             return
         refresh_time = time.time() + reconnect_interval
-        self.log.info("Scheduling forced reconnect in %d seconds. Connection will be refreshed at %s", reconnect_interval, time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(refresh_time)))
+        self.log.info(
+            "Scheduling forced reconnect in %d seconds. Connection will be refreshed at %s",
+            reconnect_interval,
+            time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(refresh_time)),
+        )
         self.loop.call_later(reconnect_interval, lambda: asyncio.create_task(self._reconnect()))
 
     async def _reconnect(self) -> None:

--- a/mautrix_telegram/abstract_user.py
+++ b/mautrix_telegram/abstract_user.py
@@ -241,6 +241,20 @@ class AbstractUser(ABC):
             use_ipv6=self.config["telegram.connection.use_ipv6"],
         )
         self.client.add_event_handler(self._update_catch)
+        self._schedule_reconnect()
+
+    def _schedule_reconnect(self) -> None:
+        reconnect_interval = self.config["telegram.force_refresh_interval_seconds"]
+        if not reconnect_interval or reconnect_interval == 0:
+            return
+        refresh_time = time.time() + reconnect_interval
+        self.log.info("Scheduling forced reconnect in %d seconds. Connection will be refreshed at %s", reconnect_interval, time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(refresh_time)))
+        self.loop.call_later(reconnect_interval, lambda: asyncio.create_task(self._reconnect()))
+
+    async def _reconnect(self) -> None:
+        self.log.info("Reconnecting to Telegram...")
+        await self.stop()
+        await self.start()
 
     @abstractmethod
     async def on_signed_out(self, err: UnauthorizedError | AuthKeyError) -> None:

--- a/mautrix_telegram/abstract_user.py
+++ b/mautrix_telegram/abstract_user.py
@@ -253,7 +253,7 @@ class AbstractUser(ABC):
             reconnect_interval,
             time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(refresh_time)),
         )
-        self.loop.call_later(reconnect_interval, lambda: asyncio.create_task(self._reconnect()))
+        self.loop.call_later(reconnect_interval, lambda: background_task.create(self._reconnect()))
 
     async def _reconnect(self) -> None:
         self.log.info("Reconnecting to Telegram...")

--- a/mautrix_telegram/config.py
+++ b/mautrix_telegram/config.py
@@ -264,6 +264,7 @@ class Config(BaseBridgeConfig):
         copy("telegram.catch_up")
         copy("telegram.sequential_updates")
         copy("telegram.exit_on_update_error")
+        copy("telegram.force_refresh_interval_seconds")
 
         copy("telegram.connection.timeout")
         copy("telegram.connection.retries")

--- a/mautrix_telegram/example-config.yaml
+++ b/mautrix_telegram/example-config.yaml
@@ -581,6 +581,8 @@ telegram:
     # Should incoming updates be handled sequentially to make sure order is preserved on Matrix?
     sequential_updates: true
     exit_on_update_error: false
+    # Interval to force refresh the connection (full reconnect), default is 1 day. Set 0 to disable force refreshes.
+    force_refresh_interval_seconds: 10
 
     # Telethon connection options.
     connection:

--- a/mautrix_telegram/example-config.yaml
+++ b/mautrix_telegram/example-config.yaml
@@ -581,8 +581,8 @@ telegram:
     # Should incoming updates be handled sequentially to make sure order is preserved on Matrix?
     sequential_updates: true
     exit_on_update_error: false
-    # Interval to force refresh the connection (full reconnect), default is 1 day. Set 0 to disable force refreshes.
-    force_refresh_interval_seconds: 10
+    # Interval to force refresh the connection (full reconnect). 0 disables it.
+    force_refresh_interval_seconds: 0
 
     # Telethon connection options.
     connection:


### PR DESCRIPTION
# Context

We've observed some scenarios where users stop getting messages. Reconnecting them seems to solve the issue.

# Description

This PR adds a new `force_refresh_interval_seconds` config option to force the connection to be refreshed. Default is 1 day. set 0 to disable force refreshes. This is the equivalent to https://github.com/mautrix/meta/pull/58.

## How to test this

Clone the branch, change `force_refresh_interval_seconds` to a small interval (eg: 10 seconds), run the bridge locally and you should see:

```
[2024-05-23 17:08:38,712] [INFO@mau.user.@REDACTED] Scheduling forced reconnect in 20 seconds. Connection will be refreshed at 2024-05-23 17:08:58

[2024-05-23 17:08:58,714] [INFO@mau.user.@REDACTED] Reconnecting to Telegram...
[2024-05-23 17:08:58,716] [INFO@telethon.611285941.network.mtprotosender] Disconnecting from 149.154.167.91:443/TcpFull...
[2024-05-23 17:08:58,720] [INFO@telethon.611285941.network.mtprotosender] Disconnection from 149.154.167.91:443/TcpFull complete!
[2024-05-23 17:08:58,722] [INFO@telethon.611285941.client.updates] Update loop finished
[2024-05-23 17:08:58,740] [INFO@telethon.611285941.client.telegrambaseclient] Saving update states
[2024-05-23 17:08:58,741] [DEBUG@mau.user.@REDACTED] Initializing client for @REDACTED
[2024-05-23 17:08:58,742] [INFO@mau.user.@REDACTED] Scheduling forced reconnect in 20 seconds. Connection will be refreshed at 2024-05-23 17:09:18
[2024-05-23 17:08:58,742] [INFO@telethon.611285941.network.mtprotosender] Connecting to 149.154.167.91:443/TcpFull...
[2024-05-23 17:08:58,775] [INFO@telethon.611285941.network.mtprotosender] Connection to 149.154.167.91:443/TcpFull complete!

[2024-05-23 17:09:18,743] [INFO@mau.user.@REDACTED] Reconnecting to Telegram...
[2024-05-23 17:09:18,743] [INFO@telethon.611285941.network.mtprotosender] Disconnecting from 149.154.167.91:443/TcpFull...
[2024-05-23 17:09:18,744] [INFO@telethon.611285941.network.mtprotosender] Disconnection from 149.154.167.91:443/TcpFull complete!
[2024-05-23 17:09:18,744] [INFO@telethon.611285941.client.updates] Update loop finished
[2024-05-23 17:09:18,745] [INFO@telethon.611285941.client.telegrambaseclient] Saving update states
[2024-05-23 17:09:18,746] [DEBUG@mau.user.@REDACTED] Initializing client for @REDACTED
[2024-05-23 17:09:18,746] [INFO@mau.user.@REDACTED] Scheduling forced reconnect in 20 seconds. Connection will be refreshed at 2024-05-23 17:09:38
```

Make sure you're still able to send and receive messages.