### PR TITLE
fix: handle ValueError when resolving unknown entities during backfill

### DIFF
--- a/mautrix_telegram/portal.py
+++ b/mautrix_telegram/portal.py
@@ -3012,11 +3012,20 @@ class Portal(DBPortal, BasePortal):
         if sender:
             intent = sender.intent_for(self)
             if not sender.displayname:
-                try:
-                    entity = await client.get_entity(sender.peer)
-                    await sender.update_info(source, entity, client_override=client)
-                except ValueError:
-                    self.log.warning(f"Could not find entity for {sender.peer}, proceeding without entity info")
+                if not hasattr(self, '_unresolvable_senders'):
+                    self._unresolvable_senders = set()
+                peer_key = str(sender.peer)
+                if peer_key not in self._unresolvable_senders:
+                    try:
+                        entity = await client.get_entity(sender.peer)
+                    except ValueError:
+                        self._unresolvable_senders.add(peer_key)
+                        self.log.warning(
+                            f"Could not find entity for {sender.peer}, proceeding without entity info",
+                            exc_info=True,
+                        )
+                    else:
+                        await sender.update_info(source, entity, client_override=client)
         else:
             intent = self.main_intent
         if (


### PR DESCRIPTION
During backfill, `get_entity()` can fail with a ValueError.  This has been causing entire backfills to abort. My best guess is that it occurs when backfilling messages from users whose accounts have been deleted, users that the Telegram session has never directly encountered and therefore has no cached entity data for, or something of the sort.

I wrapped the `get_entity()` and `update_info()` calls in a `try`/`except` block so that messages from unresolvable senders are still bridged, just without a display name for that sender. This way, my message history is still backfilled even if some of the names are wonky.

Since making this change, I've managed to backfill several Telegram chats on my self-hosted Matrix server, some with tens of thousands of messages without the backfill failing. 

- Bridge Version: 0.15.3
- Python Version 3.11.13

Here's what the original Errors looked like:
```
ValueError: Could not find the input entity for PeerUser(user_id=204010804) (PeerUser). Please read https://docs.telethon.dev/en/stable/concepts/entities.html to find out more details.

Unhandled error while handling command:
Traceback (most recent call last):
  File "/usr/lib/python3.11/site-packages/mautrix/bridge/commands/handler.py", line 491, in handle
    await self._run_handler(handler, evt)
  File "/usr/lib/python3.11/site-packages/mautrix_telegram/commands/handler.py", line 194, in _run_handler
    return await handler(evt)
           ^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/mautrix/bridge/commands/handler.py", line 340, in __call__
    return await self._handler(evt)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/mautrix_telegram/commands/telegram/misc.py", line 515, in backfill
    output = await portal.forward_backfill(evt.sender, initial=False, override_limit=limit)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/mautrix_telegram/portal.py", line 2907, in forward_backfill
    output = await asyncio.wait_for(task, timeout=timeout)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/asyncio/tasks.py", line 489, in wait_for
    return fut.result()
           ^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/mautrix_telegram/portal.py", line 2925, in backfill
    return await self._locked_backfill(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/mautrix_telegram/portal.py", line 2975, in _locked_backfill
    event_count, message_count, lowest_id = await self._backfill_messages(
                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/mautrix_telegram/portal.py", line 3107, in _backfill_messages
    converted, intent = await self._convert_batch_msg(source, client, msg)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/mautrix_telegram/portal.py", line 3015, in _convert_batch_msg
    entity = await client.get_entity(sender.peer)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/telethon/client/users.py", line 309, in get_entity
    inputs.append(await self.get_input_entity(x))
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/telethon/client/users.py", line 485, in get_input_entity
    raise ValueError(
ValueError: Could not find the input entity for PeerUser(user_id=204010804) (PeerUser). Please read https://docs.telethon.dev/en/stable/concepts/entities.html to find out more details.
```     