### PR TITLE
Fix bot not being invited to direct chats for backfill (#669)

### DIFF
--- a/mautrix_telegram/portal.py
+++ b/mautrix_telegram/portal.py
@@ -1006,6 +1006,12 @@ class Portal(DBPortal, BasePortal):
             )
             if self.is_direct:
                 create_invites.add(self.az.bot_mxid)
+        # Invite bot to direct chats when backfill is enabled,
+        # even without encryption. Fixes bot not being able to join
+        # for backfill in unencrypted private portals.
+        # See: https://github.com/mautrix/telegram/issues/669
+        if self.is_direct and self.backfill_enable and self.az.bot_mxid not in create_invites:
+            create_invites.add(self.az.bot_mxid)
         if self.is_direct:
             assert puppet is not None
             self.title = puppet.displayname


### PR DESCRIPTION
Problem
When backfill.enable is true but encryption.default is false, the bridge bot
(@telegrambot:server) is not invited to newly created direct chat portal rooms.
The bot is only added to create_invites inside the encryption block
(if self.config["bridge.encryption.default"] and self.matrix.e2ee), but
forward_backfill() always runs after room creation when backfill is enabled.
This causes repeated MForbidden: You are not invited to this room errors:

On initial portal creation (backfill fails silently)
On every bridge restart (sync backfill retries and fails again)

Root Cause
In _create_matrix_room() in portal.py, the bot is added to create_invites
only when encryption is enabled (for encrypted DMs the bot must be in the room).
However, the backfill code path (forward_backfill) also requires the bot to be
a room member to send backfilled messages, regardless of encryption status.
Fix
Add the bot to create_invites for direct chats when backfill is enabled,
independent of encryption settings. The not in create_invites guard prevents
duplicate invites when encryption is also active.
pythonif self.is_direct and self.backfill_enable and self.az.bot_mxid not in create_invites:
    create_invites.add(self.az.bot_mxid)
Testing

Tested on a fresh single-user Synapse instance with mautrix-telegram v0.15.2
Verified with both encryption.default: false and encryption.default: true
All direct chat portals now create successfully with the bot as member
Backfill completes without errors on portal creation and bridge restart
No impact on group chat portal creation

Fixes #669