### PR TITLE
fix(provisioning): resolve API 500 errors by using new-style aiohttp middleware

### DIFF
--- a/mautrix_telegram/web/provisioning/__init__.py
+++ b/mautrix_telegram/web/provisioning/__init__.py
@@ -623,22 +623,20 @@ class ProvisioningAPI(AuthAPI):
         )
 
     @staticmethod
+    @web.middleware
     async def error_middleware(
-        _, handler: Callable[[web.Request], Awaitable[web.Response]]
-    ) -> Callable[[web.Request], Awaitable[web.Response]]:
-        async def middleware_handler(request: web.Request) -> web.Response:
-            try:
-                return await handler(request)
-            except web.HTTPException as ex:
-                return web.json_response(
-                    {
-                        "error": f"Unhandled HTTP {ex.status}",
-                        "errcode": f"unhandled_http_{ex.status}",
-                    },
-                    status=ex.status,
-                )
-
-        return middleware_handler
+        request: web.Request, handler: Callable[[web.Request], Awaitable[web.Response]]
+    ) -> web.Response:
+        try:
+            return await handler(request)
+        except web.HTTPException as ex:
+            return web.json_response(
+                {
+                    "error": f"Unhandled HTTP {ex.status}",
+                    "errcode": f"unhandled_http_{ex.status}",
+                },
+                status=ex.status,
+            )
 
     @staticmethod
     def get_error_response(status=200, errcode="", error="") -> web.Response:


### PR DESCRIPTION
The `error_middleware` in the provisioning API uses old-style aiohttp middleware (`(app, handler) -> handler_fn`). This works fine on a standalone `web.Application`, but since provisioning is mounted as a subapp, aiohttp returns the inner handler function instead of calling it, resulting in every endpoint returning 500.