### PR TITLE
Fix image dimensions for photos with EXIF orientation

### DIFF
--- a/mautrix_telegram/portal_util/message_convert.py
+++ b/mautrix_telegram/portal_util/message_convert.py
@@ -468,8 +468,8 @@ class TelegramMessageConverter:
         if not file:
             return None
         info = ImageInfo(
-            height=largest_size.h,
-            width=largest_size.w,
+            height=file.height or largest_size.h,
+            width=file.width or largest_size.w,
             orientation=0,
             mimetype=file.mime_type,
             size=self._photo_size_key(largest_size),

--- a/mautrix_telegram/util/file_transfer.py
+++ b/mautrix_telegram/util/file_transfer.py
@@ -97,6 +97,28 @@ def convert_image(
         return source_mime, file, None, None
 
 
+def _get_image_dimensions(file: bytes) -> tuple[int | None, int | None]:
+    """Get image dimensions from file bytes, accounting for EXIF orientation.
+
+    Returns (width, height) with dimensions swapped for 90/270 degree rotations.
+    """
+    if not Image:
+        return None, None
+    try:
+        img = Image.open(BytesIO(file))
+        w, h = img.size
+        try:
+            exif = img.getexif()
+            orientation = exif.get(274)  # Orientation tag
+        except Exception:
+            orientation = None
+        if orientation in (5, 6, 7, 8):
+            return h, w
+        return w, h
+    except Exception:
+        return None, None
+
+
 async def _read_video_thumbnail(data: bytes, mime_type: str) -> tuple[bytes, int, int]:
     first_frame = await ffmpeg.convert_bytes(
         data,
@@ -345,6 +367,8 @@ async def _unlocked_transfer_file_to_matrix(
 
         width, height = None, None
         mime_type = magic.mimetype(file)
+        if mime_type.startswith("image/") and not is_sticker:
+            width, height = _get_image_dimensions(file)
 
         image_converted = False
         is_tgs = mime_type == "application/gzip"


### PR DESCRIPTION
Fixes #603

## Summary
- When an image contains EXIF orientation metadata that rotates it 90 or 270 degrees, the bridge previously reported the raw pixel dimensions, causing the image to appear squashed in Matrix clients
- Reads EXIF orientation during file transfer and swaps width/height for orientations that require rotation (values 5, 6, 7, 8)
- Photo conversion prefers the EXIF-corrected dimensions from the database over Telegram's raw values

## Changes
- `util/file_transfer.py`: Add `_get_image_dimensions()` helper that reads EXIF orientation tag (274) and returns display-corrected dimensions
- `util/file_transfer.py`: Call `_get_image_dimensions()` for non-sticker images during file transfer, storing corrected dimensions in `DBTelegramFile`
- `portal_util/message_convert.py`: In `_convert_photo()`, prefer `file.width/height` (EXIF-corrected) over `largest_size.w/h` (raw Telegram values)

## Test plan
- [ ] Send a photo with EXIF orientation 6 (90° CW) from Telegram and verify Matrix receives correct (swapped) width/height
- [ ] Send a normal photo without EXIF rotation and verify dimensions are unchanged
- [ ] Send a photo with EXIF orientation 3 (180°) and verify dimensions are not swapped
- [ ] Verify sticker dimensions are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)