### PR TITLE
Fix contact names leaking when allow_contact_info is false

### DIFF
--- a/mautrix_telegram/puppet.py
+++ b/mautrix_telegram/puppet.py
@@ -363,6 +363,12 @@ class Puppet(DBPuppet, BasePuppet):
             allow_because = "target user is a channel"
         elif not isinstance(info, UpdateUserName) and not info.contact:
             allow_because = "target user is not a contact"
+        elif (
+            not isinstance(info, (Channel, UpdateUserName))
+            and info.contact
+            and not self.config["bridge.allow_contact_info"]
+        ):
+            return False
         elif not self.displayname_source:
             allow_because = "no primary source set"
         elif not self.displayname:


### PR DESCRIPTION
Fixes #975

## Summary
- When `allow_contact_info` is set to `false`, contact-based displaynames were still being applied to new puppets that had no primary displayname source
- The "no primary source set" allow condition (line 366) permitted the update before the contact status rejection check could evaluate
- The rejection check also required `self.displayname` to be truthy, which is never the case for new puppets
- `displayname_contact` defaults to `True` in the database, making the status comparison always pass

## Root Cause
Three issues combined:
1. The allow condition chain had no contact-info guard for the "no primary source" and "no displayname" branches
2. The rejection check at line 378 required `self.displayname` to be truthy, bypassing new puppets
3. `displayname_contact` defaults to `True` in the DB model, so the rejection check's status comparison (`is_contact_name != displayname_contact`) always evaluated to `False`

## Changes
- `puppet.py`: Add early rejection condition in the allow chain that checks contact status against `bridge.allow_contact_info`
- Positioned after same-source and non-contact conditions so those legitimate updates are still allowed
- Relaybot/bot sources and same-source updates are still permitted (checked earlier in the chain)

## Test plan
- [ ] Set `allow_contact_info: false`, log in with a Telegram account that has contacts with custom displaynames, verify puppets do not get contact names
- [ ] Set `allow_contact_info: true`, verify contact names ARE applied (no regression)
- [ ] Verify same-source updates still work (user who originally set the name can update it)
- [ ] Verify non-contact names are still applied correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)