### PR TITLE
Add m.sticker to default message_formats

### DIFF
--- a/mautrix_telegram/example-config.yaml
+++ b/mautrix_telegram/example-config.yaml
@@ -478,6 +478,7 @@ bridge:
         m.audio: "$distinguisher <b>$sender_displayname</b> sent an audio file: $message"
         m.video: "$distinguisher <b>$sender_displayname</b> sent a video: $message"
         m.location: "$distinguisher <b>$sender_displayname</b> sent a location: $message"
+        m.sticker: "$distinguisher <b>$sender_displayname</b> sent a sticker"
     # Telegram doesn't have built-in emotes, this field specifies how m.emote's from authenticated
     # users are sent to telegram. All fields in message_formats are supported. Additionally, the
     # Telegram user info is available in the following variables:


### PR DESCRIPTION
Fixes #523

## Summary
- Add `m.sticker` to the default `message_formats` in `example-config.yaml`
- Previously, users could not customize the sticker message format because `m.sticker` was missing from defaults
- The config migration's `copy_dict` with `override_existing_map=False` would drop any user-added `m.sticker` key on every startup, making custom sticker formats impossible to persist
- The relaybot sticker caption path already existed (portal.py:2339-2355) and applied message formats — it just couldn't find the `m.sticker` config key

## Changes
- `example-config.yaml`: Add `m.sticker: "$distinguisher <b>$sender_displayname</b> sent a sticker"` to `bridge.message_formats`

## How it works
The relaybot path for stickers already:
1. Creates a `TextMessageEventContent` caption from the sticker body (portal.py:2344)
2. Sets `caption_content.msgtype = MessageType.STICKER` (portal.py:2354)
3. Calls `_pre_process_matrix_message` → `_apply_msg_format` (portal.py:2355)
4. Looks up `message_formats.m.sticker` (portal.py:1740)

The only thing missing was the config key itself.

## Test plan
- [ ] Set up relaybot mode, send a sticker from Matrix, verify the Telegram message includes the sender's name as a caption
- [ ] Customize `bridge.message_formats.m.sticker` in config, restart bridge, verify the custom format is preserved
- [ ] Send a sticker from a logged-in user, verify no caption is added (name visible from Telegram account)
- [ ] Run config generation/update, verify `m.sticker` is not dropped

🤖 Generated with [Claude Code](https://claude.com/claude-code)