### PR TITLE
Fix crash when joining tg:// protocol links

### DIFF
--- a/mautrix_telegram/commands/telegram/misc.py
+++ b/mautrix_telegram/commands/telegram/misc.py
@@ -20,6 +20,7 @@ import base64
 import codecs
 import re
 import shlex
+from urllib.parse import parse_qs, urlparse
 
 from aiohttp import ClientSession, InvalidURL
 from telethon.errors import (
@@ -266,6 +267,23 @@ async def join(evt: CommandEvent) -> EventID | None:
         return await evt.reply("**Usage:** `$cmdprefix+sp join <invite link>`")
 
     url = evt.args[0]
+
+    if url.startswith("tg://"):
+        try:
+            parsed = urlparse(url)
+            params = parse_qs(parsed.query)
+            if "domain" in params:
+                url = f"https://t.me/{params['domain'][0]}"
+            elif "invite" in params:
+                url = f"https://t.me/+{params['invite'][0]}"
+            else:
+                return await evt.reply(
+                    "Failed to parse tg:// link. "
+                    "Expected tg://resolve?domain=... or tg://join?invite=..."
+                )
+        except Exception as e:
+            return await evt.reply(f"Failed to parse tg:// link: {e}")
+
     if evt.config["bridge.invite_link_resolve"]:
         try:
             async with ClientSession() as sess, sess.get(url) as resp:


### PR DESCRIPTION
Fixes #966

## Summary
- The `!tg join` command crashed with `AssertionError` when passed `tg://` protocol links because aiohttp only supports `http://` and `https://` schemes
- The `InvalidURL` exception handler didn't catch `AssertionError`
- Convert `tg://` links to `https://t.me/` format before processing

## Changes
- `commands/telegram/misc.py`: Add `tg://` URL conversion before the HTTP request
  - `tg://resolve?domain=ABC` → `https://t.me/ABC`
  - `tg://join?invite=XXX` → `https://t.me/+XXX`
- Uses `urllib.parse` (stdlib) for robust URL parsing

## Test plan
- [ ] Run `!tg join tg://resolve?domain=durov` and verify it joins the channel
- [ ] Run `!tg join tg://join?invite=ABC` and verify it joins via invite
- [ ] Verify `!tg join https://t.me/ABC` still works (no regression)
- [ ] Verify an invalid `tg://` link returns a helpful error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)