### PR TITLE
Fix avatar flipping on every message from different logged-in users

### DIFF
--- a/mautrix_telegram/puppet.py
+++ b/mautrix_telegram/puppet.py
@@ -440,6 +440,20 @@ class Puppet(DBPuppet, BasePuppet):
             return False
         if not photo_id and not self.config["bridge.allow_avatar_remove"]:
             return False
+        if (
+            self.avatar_set
+            and self.displayname_source is not None
+            and source.tgid != self.displayname_source
+            and not (source.is_relaybot or source.is_bot)
+        ):
+            self.log.debug(
+                "Ignoring avatar update for %s from non-primary source %s "
+                "(primary source is %s)",
+                self.id,
+                source.tgid,
+                self.displayname_source,
+            )
+            return False
         if self.photo_id != photo_id or not self.avatar_set:
             if not photo_id:
                 self.photo_id = ""


### PR DESCRIPTION
## Summary

- Gate puppet avatar updates to only proceed from the same source user that set the displayname (the "primary source")
- This prevents constant avatar re-downloads and flipping caused by Telegram's contacts-only avatar feature, which returns different `photo_id` values depending on which user's client fetches the entity data
- Bots and relaybot are always allowed; the first avatar set is allowed from any source
- Mirrors the existing source-gating pattern already used in `update_displayname`

Fixes #889

🤖 Generated with [Claude Code](https://claude.com/claude-code)