### PR TITLE
client: treat pool.ErrConnDead as transient in onPing

### DIFF
--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -47,6 +47,7 @@ import (
 	"go.mau.fi/mautrix-telegram/pkg/connector/matrixfmt"
 	"go.mau.fi/mautrix-telegram/pkg/connector/store"
 	"go.mau.fi/mautrix-telegram/pkg/connector/telegramfmt"
+	"go.mau.fi/mautrix-telegram/pkg/gotd/pool"
 	"go.mau.fi/mautrix-telegram/pkg/gotd/telegram"
 	"go.mau.fi/mautrix-telegram/pkg/gotd/telegram/auth"
 	"go.mau.fi/mautrix-telegram/pkg/gotd/telegram/updates"
@@ -418,12 +419,12 @@ func (tc *TelegramClient) onPing() {
 	me, err := tc.client.Self(ctx)
 	if auth.IsUnauthorized(err) {
 		tc.onAuthError(err)
-	} else if errors.Is(err, syscall.EPIPE) {
-		// This is a pipe error, try disconnecting which will force the
-		// updatesManager to fail and cause the client to reconnect.
+	} else if errors.Is(err, syscall.EPIPE) || errors.Is(err, pool.ErrConnDead) {
+		// Connectivity error — connection died during the Self() call.
+		// Keep as transient; gotd's backoff will reconnect.
 		tc.userLogin.BridgeState.Send(status.BridgeState{
 			StateEvent: status.StateTransientDisconnect,
-			Error:      "pipe-error",
+			Error:      "connectivity-error",
 			Message:    humanise.Error(err),
 		})
 	} else if err != nil {


### PR DESCRIPTION
## Problem

When a Telegram DC connection dies, `onDead()` correctly sends `TRANSIENT_DISCONNECT`. However, `onPing()` fires shortly after (pong received on reconnecting transport), calls `Self()`, and `Self()` races with connection death — `waitSession()` returns `pool.ErrConnDead`.

This error is not `EPIPE` (which is already handled as transient on line 421), so it falls through to `sendBadCredentialsOrUnknownError()` → `UNKNOWN_ERROR` with the raw Go error string `"waitSession: connection dead"`.

The Android client renders `UNKNOWN_ERROR` as **"Account Disconnected"** with the raw error — a dead-end UI with no spinner or action button. The bridge self-recovers via gotd backoff in ~2 minutes, but the user sees a permanent-looking failure.

## Fix

Add `pool.ErrConnDead` alongside `syscall.EPIPE` in the `onPing` error handling. Both are transient connectivity errors where the connection died during an API call. The bridge stays in `TRANSIENT_DISCONNECT`, and the client correctly renders it with a 5s buffer and "Temporarily Disconnected" banner.

## Impact

- User no longer sees "Account Disconnected / waitSession: connection dead" during self-healing DC outages
- Client shows "Temporarily Disconnected" with reconnection messaging instead
- No change to `UNKNOWN_ERROR` handling for actual auth/permanent failures