### PR TITLE
connector: allow disabling contact list fetching

### DIFF
--- a/pkg/connector/capabilities.go
+++ b/pkg/connector/capabilities.go
@@ -41,7 +41,7 @@ func (tc *TelegramConnector) GetCapabilities() *bridgev2.NetworkGeneralCapabilit
 				CreateDM:       true,
 				LookupPhone:    true,
 				LookupUsername: true,
-				ContactList:    true,
+				ContactList:    tc.Config.ContactListEnabled(),
 				Search:         true,
 			},
 			GroupCreation: map[string]bridgev2.GroupTypeCapabilities{

--- a/pkg/connector/config.go
+++ b/pkg/connector/config.go
@@ -77,6 +77,10 @@ type TelegramConfig struct {
 
 	ProxyConfig ProxyConfig `yaml:"proxy"`
 
+	ContactList struct {
+		Enabled *bool `yaml:"enabled"`
+	} `yaml:"contact_list"`
+
 	Sync struct {
 		UpdateLimit int  `yaml:"update_limit"`
 		CreateLimit int  `yaml:"create_limit"`
@@ -104,6 +108,10 @@ type TelegramConfig struct {
 
 func (c TelegramConfig) ShouldBridge(participantCount int) bool {
 	return c.MaxMemberCount < 0 || participantCount <= c.MaxMemberCount
+}
+
+func (c TelegramConfig) ContactListEnabled() bool {
+	return c.ContactList.Enabled == nil || *c.ContactList.Enabled
 }
 
 type DisplaynameParams struct {
@@ -174,6 +182,7 @@ func upgradeConfig(helper up.Helper) {
 	helper.Copy(up.Str|up.Null, "proxy", "address")
 	helper.Copy(up.Str|up.Null, "proxy", "username")
 	helper.Copy(up.Str|up.Null, "proxy", "password")
+	helper.Copy(up.Bool, "contact_list", "enabled")
 	helper.Copy(up.Int, "sync", "update_limit")
 	helper.Copy(up.Int, "sync", "create_limit")
 	helper.Copy(up.Int, "sync", "login_sync_limit")

--- a/pkg/connector/example-config.yaml
+++ b/pkg/connector/example-config.yaml
@@ -65,6 +65,11 @@ proxy:
     username:
     password:
 
+contact_list:
+    # Allow clients/provisioning API to fetch Telegram contacts.
+    # Fetching contacts may create Matrix ghost users for those contacts.
+    enabled: true
+
 sync:
     # Number of most recently active dialogs to check when syncing chats.
     # Set to -1 to remove limit.

--- a/pkg/connector/startchat.go
+++ b/pkg/connector/startchat.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/rs/zerolog"
 	"go.mau.fi/util/ptr"
+	"maunium.net/go/mautrix"
 	"maunium.net/go/mautrix/bridgev2"
 
 	"go.mau.fi/mautrix-telegram/pkg/connector/ids"
@@ -231,6 +232,9 @@ func (tc *TelegramClient) SearchUsers(ctx context.Context, query string) (resp [
 }
 
 func (tc *TelegramClient) GetContactList(ctx context.Context) (resp []*bridgev2.ResolveIdentifierResponse, err error) {
+	if !tc.main.Config.ContactListEnabled() {
+		return nil, bridgev2.RespError(mautrix.MForbidden.WithMessage("Telegram contact list fetching is disabled"))
+	}
 	tc.contactsLock.Lock()
 	defer tc.contactsLock.Unlock()
 	var contacts *tg.ContactsContacts


### PR DESCRIPTION
## Summary

Adds a `contact_list.enabled` configuration option for the Telegram connector.

When disabled, the bridge:
- stops advertising contact-list support in provisioning capabilities
- rejects `GetContactList` calls with `M_FORBIDDEN`

The default is unchanged: contact list fetching remains enabled when the option is omitted.

## Why

Fetching Telegram contacts can create/update Matrix ghost users for many contacts. Some homeserver admins want identifier lookup and normal bridging, but do not want clients or provisioning API users to import their full Telegram contact list.

## Testing

- `go test ./pkg/connector/...`
