### PR TITLE
client: fix mtproxy support

### DIFF
--- a/pkg/connector/example-config.yaml
+++ b/pkg/connector/example-config.yaml
@@ -57,7 +57,6 @@ ping:
 # Proxy settings
 proxy:
     # Allowed types: disabled, socks5, mtproxy
-    # Note: mtproxy support is probably broken currently
     type: disabled
     # Proxy IP address/domain name and port.
     address: "127.0.0.1:1080"

--- a/pkg/connector/proxy.go
+++ b/pkg/connector/proxy.go
@@ -17,6 +17,7 @@
 package connector
 
 import (
+	"encoding/hex"
 	"fmt"
 
 	"golang.org/x/net/proxy"
@@ -54,7 +55,11 @@ func GetProxyResolver(cfg ProxyConfig) (dcs.Resolver, error) {
 		resolver := dcs.Plain(dcs.PlainOptions{Dial: dialer})
 		return resolver, nil
 	case "mtproxy":
-		return dcs.MTProxy(cfg.Address, []byte(cfg.Password), dcs.MTProxyOptions{})
+		secret, err := hex.DecodeString(cfg.Password)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode secret: %w", err)
+		}
+		return dcs.MTProxy(cfg.Address, secret, dcs.MTProxyOptions{})
 	default:
 		return nil, fmt.Errorf("unsupported proxy type %s", cfg.Type)
 	}


### PR DESCRIPTION
mtproxies weren't working because secret has been just casted to string, but it should have been decoded as hex string

### Checklist

* [x] I have read and followed the contributing guidelines at <https://docs.mau.fi/bridges/general/contributing.html>
