### PR TITLE
fix: MTProxy secret decoding and AES-CTR stream desync

### DIFF
--- a/pkg/connector/example-config.yaml
+++ b/pkg/connector/example-config.yaml
@@ -61,6 +61,8 @@ proxy:
     # Proxy IP address/domain name and port.
     address: "127.0.0.1:1080"
     # Proxy authentication (optional). Put MTProxy secret in password field.
+    # MTProxy secret can be in hex (e.g. ee852380f362a09343efb4690c4e17862e676f6f676c652e636f6d),
+    # base64, or raw format. The bridge auto-detects the encoding.
     username:
     password:
 

--- a/pkg/connector/proxy.go
+++ b/pkg/connector/proxy.go
@@ -17,11 +17,11 @@
 package connector
 
 import (
-	"encoding/hex"
 	"fmt"
 
 	"golang.org/x/net/proxy"
 
+	"go.mau.fi/mautrix-telegram/pkg/gotd/mtproxy"
 	"go.mau.fi/mautrix-telegram/pkg/gotd/telegram/dcs"
 )
 
@@ -55,11 +55,11 @@ func GetProxyResolver(cfg ProxyConfig) (dcs.Resolver, error) {
 		resolver := dcs.Plain(dcs.PlainOptions{Dial: dialer})
 		return resolver, nil
 	case "mtproxy":
-		secret, err := hex.DecodeString(cfg.Password)
-		if err != nil {
-			return nil, fmt.Errorf("failed to decode secret: %w", err)
-		}
-		return dcs.MTProxy(cfg.Address, secret, dcs.MTProxyOptions{})
+		secret, err := mtproxy.ParseSecretString(cfg.Password)
+        if err != nil {
+			return nil, fmt.Errorf("parse MTProxy secret: %w", err)
+        }
+        return dcs.MTProxy(cfg.Address, secret, dcs.MTProxyOptions{})
 	default:
 		return nil, fmt.Errorf("unsupported proxy type %s", cfg.Type)
 	}

--- a/pkg/gotd/mtproxy/obfuscated2/obfuscated2.go
+++ b/pkg/gotd/mtproxy/obfuscated2/obfuscated2.go
@@ -53,7 +53,7 @@ func (o *Obfuscated2) Read(b []byte) (int, error) {
 		return n, err
 	}
 	if n > 0 {
-		o.decrypt.XORKeyStream(b, b)
+		o.decrypt.XORKeyStream(b[:n], b[:n])
 	}
 	return n, err
 }

--- a/pkg/gotd/mtproxy/secret.go
+++ b/pkg/gotd/mtproxy/secret.go
@@ -1,6 +1,11 @@
 package mtproxy
 
 import (
+	"encoding/base64"
+	"encoding/hex"
+	"strings"
+	"unicode"
+
 	"github.com/go-faster/errors"
 
 	"go.mau.fi/mautrix-telegram/pkg/gotd/proto/codec"
@@ -41,6 +46,48 @@ func (s Secret) ExpectedCodec() (cdc codec.Codec, _ bool) {
 	}
 
 	return cdc, true
+}
+
+// ParseSecretString parses a secret from a string, auto-detecting the encoding format.
+// Supported formats:
+//   - Hex-encoded (e.g. "ee852380f362a09343efb4690c4e17862e676f6f676c652e636f6d")
+//   - Base64-encoded (e.g. "eehSO..." with URL-safe or standard base64)
+//   - Raw bytes (16-34 bytes)
+func ParseSecretString(secret string) ([]byte, error) {
+	secret = strings.TrimSpace(secret)
+	if secret == "" {
+		return nil, errors.New("empty secret")
+	}
+
+	if decoded, err := hex.DecodeString(secret); err == nil {
+		return decoded, nil
+	}
+
+	for _, enc := range []*base64.Encoding{
+		base64.RawURLEncoding,
+		base64.RawStdEncoding,
+		base64.URLEncoding,
+		base64.StdEncoding,
+	} {
+		if decoded, err := enc.DecodeString(secret); err == nil {
+			return decoded, nil
+		}
+	}
+
+	if isAllHex(secret) {
+		return nil, errors.Errorf("secret looks like hex but failed to decode: %q", secret)
+	}
+
+	return []byte(secret), nil
+}
+
+func isAllHex(s string) bool {
+	for _, c := range s {
+		if !unicode.Is(unicode.ASCII_Hex_Digit, c) {
+			return false
+		}
+	}
+	return len(s)%2 == 0
 }
 
 // ParseSecret checks and parses secret.

--- a/pkg/gotd/mtproxy/secret_test.go
+++ b/pkg/gotd/mtproxy/secret_test.go
@@ -40,3 +40,63 @@ func TestParseSecret(t *testing.T) {
 		})
 	}
 }
+
+func TestParseSecretString(t *testing.T) {
+	tests := []struct {
+		name    string
+		secret  string
+		wantLen int
+		wantErr bool
+	}{
+		{
+			name:    "hex-simple",
+			secret:  "52a493bdfb90eea55739eabff2d92a14",
+			wantLen: 16,
+		},
+		{
+			name:    "hex-secured",
+			secret:  "ddf05fb7acb549be047a7c585116581418",
+			wantLen: 17,
+		},
+		{
+			name:    "hex-tls",
+			secret:  "ee852380f362a09343efb4690c4e17862e676f6f676c652e636f6d",
+			wantLen: 27,
+		},
+		{
+			name:    "base64url-secured",
+			secret:  "3fBPt6tFSb4EenxYURZYFBg",
+			wantLen: 17,
+		},
+		{
+			name:    "raw-bytes-secured",
+			secret:  "\xdd\xf0_\xb7\xac\xb5I\xbe\x04z|XQ\x16X\x14\x18",
+			wantLen: 17,
+		},
+		{
+			name:    "hex-with-whitespace",
+			secret:  "  ddf05fb7acb549be047a7c585116581418  ",
+			wantLen: 17,
+		},
+		{
+			name:    "empty",
+			secret:  "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseSecretString(tt.secret)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, got, tt.wantLen)
+
+			parsed, err := ParseSecret(got)
+			require.NoError(t, err)
+			require.NotZero(t, parsed.Type)
+		})
+	}
+}


### PR DESCRIPTION
### Checklist

* [ V] I have read and followed the contributing guidelines at <https://docs.mau.fi/bridges/general/contributing.html>

Couldn't join [#telegram:maunium.net](https://matrix.to/#/#telegram:maunium.net) for unknown reason, sorry.

## Title: fix: MTProxy support
## Description:
Two bugs prevented MTProxy from working:
1. Secret decoding (proxy.go, secret.go)
`dcs.MTProxy()` expects raw bytes, but the secret in config is usually hex or base64 encoded. Previously the string was cast to bytes as-is, which caused "unknown tag" errors. Added `ParseSecretString()` that auto-detects the encoding (hex, base64, or raw) and decodes accordingly.
2. AES-CTR stream desync (obfuscated2/obfuscated2.go)
`Read()` returns `n` — the number of bytes actually read, which can be less than the buffer size. The old code ran `XORKeyStream` on the full buffer `b` instead of `b[:n]`, advancing the cipher stream by too many bytes. This corrupted decryption of all subsequent messages. Fix: use `b[:n]`.

Tested manually on my tuwunel Matrix server: login works, chats and contacts sync correctly through MTProxy.

#1stPRever