### PR TITLE
Reintroduce `max_telegram_delete`

### DIFF
--- a/pkg/connector/config.go
+++ b/pkg/connector/config.go
@@ -93,6 +93,7 @@ type TelegramConfig struct {
 	ContactAvatars                       bool                `yaml:"contact_avatars"`
 	ContactNames                         bool                `yaml:"contact_names"`
 	MaxMemberCount                       int                 `yaml:"max_member_count"`
+	MaxTelegramDelete                    int                 `yaml:"max_telegram_delete"`
 	AlwaysCustomEmojiReaction            bool                `yaml:"always_custom_emoji_reaction"`
 	SavedMessagesAvatar                  id.ContentURIString `yaml:"saved_message_avatar"`
 	AlwaysTombstoneOnSupergroupMigration bool                `yaml:"always_tombstone_on_supergroup_migration"`
@@ -105,6 +106,10 @@ type TelegramConfig struct {
 
 func (c TelegramConfig) ShouldBridge(participantCount int) bool {
 	return c.MaxMemberCount < 0 || participantCount <= c.MaxMemberCount
+}
+
+func (c TelegramConfig) ShouldBridgeDeletion(deletedMessageCount int) bool {
+	return c.MaxTelegramDelete < 0 || deletedMessageCount <= c.MaxTelegramDelete
 }
 
 type DisplaynameParams struct {
@@ -185,6 +190,7 @@ func upgradeConfig(helper up.Helper) {
 	helper.Copy(up.Bool, "contact_avatars")
 	helper.Copy(up.Bool, "contact_names")
 	helper.Copy(up.Int, "max_member_count")
+	helper.Copy(up.Int, "max_telegram_delete")
 	helper.Copy(up.Bool, "always_custom_emoji_reaction")
 	helper.Copy(up.Str, "saved_message_avatar")
 	helper.Copy(up.Bool, "always_tombstone_on_supergroup_migration")

--- a/pkg/connector/example-config.yaml
+++ b/pkg/connector/example-config.yaml
@@ -96,6 +96,12 @@ takeout:
 #
 # -1 means no limit (which means all chats can be bridged)
 max_member_count: -1
+# The maximum number of simultaneous Telegram message deletions to handle.
+# If a single Telegram update deletes more than this many messages, the entire
+# deletion is ignored instead of being bridged as Matrix redactions.
+#
+# -1 means no limit
+max_telegram_delete: -1
 # Should personal avatars (that are only visible to specific users) be allowed?
 contact_avatars: false
 # Should contact names be updated from any source even if a name is already set?

--- a/pkg/connector/handletelegram.go
+++ b/pkg/connector/handletelegram.go
@@ -795,7 +795,18 @@ func (tc *TelegramClient) onUserName(ctx context.Context, e tg.Entities, update 
 }
 
 func (tc *TelegramClient) onDeleteMessages(ctx context.Context, channelID int64, update IGetMessages) error {
-	for _, messageID := range update.GetMessages() {
+	messages := update.GetMessages()
+
+	if !tc.main.Config.ShouldBridgeDeletion(len(messages)) {
+		zerolog.Ctx(ctx).Info().
+			Int64("channel_id", channelID).
+			Int("deleted_message_count", len(messages)).
+			Int("max_telegram_delete", tc.main.Config.MaxTelegramDelete).
+			Msg("Ignoring mass deletion of messages on Telegram to preserve the Matrix history")
+		return nil
+	}
+
+	for _, messageID := range messages {
 		wrappedMessageID := ids.MakeMessageID(channelID, messageID)
 		var portalKey networkid.PortalKey
 		var ok bool


### PR DESCRIPTION
This PR reintroduces `max_telegram_delete`, which disappeared during the Go rewrite.
The option can be used to specify the maximum number of simultaneous Telegram message deletions to handle.

In the Python bridge, it was a load/performance-related option, but I found it extremely useful for avoiding accidental or reckless deletion. Telegram has a "delete all messages on both sides" button, which can remove years of memories with two button presses...

The default was `10` in Python; here I set `-1` in order not to change the original Go behavior.

### Checklist

* [x] I have read and followed the contributing guidelines at <https://docs.mau.fi/bridges/general/contributing.html>
