### PR TITLE
gotd/pool: don't lose connections handed to a cancelled waiter

### DIFF
--- a/pkg/gotd/pool/pool.go
+++ b/pkg/gotd/pool/pool.go
@@ -207,11 +207,9 @@ retry:
 	case <-c.stuck.Ready():
 		c.log.Debug("Some connection dead, try to create new connection, cancel waiting")
 
-		c.freeReq.delete(key)
-		select {
-		default:
-		case conn, ok := <-ch:
-			if ok && conn != nil {
+		if !c.freeReq.delete(key) {
+			// transfer took the request, so a connection is on its way and must not be dropped.
+			if conn, ok := <-ch; ok && conn != nil {
 				return conn, nil
 			}
 		}
@@ -224,11 +222,10 @@ retry:
 	}
 
 	// Executed only if at least one of context is Done.
-	c.freeReq.delete(key)
-	select {
-	default:
-	case conn, ok := <-ch:
-		if ok && conn != nil {
+	if !c.freeReq.delete(key) {
+		// transfer took the request, so a connection is on its way and must be given back to the
+		// pool instead of being left in the channel.
+		if conn, ok := <-ch; ok && conn != nil {
 			c.release(conn)
 		}
 	}

--- a/pkg/gotd/pool/req_map.go
+++ b/pkg/gotd/pool/req_map.go
@@ -56,8 +56,12 @@ func (r *reqMap) transfer(c *poolConn) bool {
 	return true
 }
 
-func (r *reqMap) delete(key reqKey) {
+// delete removes the pending request. It returns false if transfer already claimed the request,
+// which means a connection is about to be sent to the request channel.
+func (r *reqMap) delete(key reqKey) bool {
 	r.mux.Lock()
+	_, ok := r.m[key]
 	delete(r.m, key)
 	r.mux.Unlock()
+	return ok
 }


### PR DESCRIPTION
## Problem

`DC.acquire`'s third case (wait for a free connection) can permanently lose a live connection.

`reqMap.transfer` removes the waiting request's key from the map, unlocks `r.mux`, and only then sends the connection on the request's buffered channel. A waiter whose context is cancelled inside that window calls `reqMap.delete` (now a no-op, the key is gone) and then does a **non-blocking** receive, which finds the channel still empty. The connection is then sent into a channel nobody will ever read:

- it never goes back to `c.free`,
- it is still counted in `c.total`,
- it stays alive, so it never triggers `c.dead` / `c.stuck` and the pool cannot recover.

Sub-DC pools are created with `max = 1` (`Client.invokeSub`), so one lost connection wedges every subsequent `acquire` on that datacenter until the process restarts.
