### PR TITLE
handlematrix: parallelize media uploads to Telegram

### DIFF
--- a/pkg/connector/handlematrix.go
+++ b/pkg/connector/handlematrix.go
@@ -82,6 +82,8 @@ var (
 	_ bridgev2.MembershipHandlingNetworkAPI     = (*TelegramClient)(nil)
 )
 
+const telegramMediaUploadThreads = 4
+
 func getMediaFilename(content *event.MessageEventContent) (filename string) {
 	if content.FileName != "" {
 		filename = content.FileName
@@ -329,7 +331,10 @@ func (tc *TelegramClient) transferMediaToTelegram(ctx context.Context, content *
 			info.MimeType = "image/jpeg"
 		}
 
-		upload, err = uploader.NewUploader(tc.client.API()).FromPath(ctx, uploadFilename, filename)
+		upload, err = uploader.NewUploader(tc.client.API()).
+			WithThreads(telegramMediaUploadThreads).
+			WithPartSize(uploader.MaximumPartSize).
+			FromPath(ctx, uploadFilename, filename)
 		return
 	})
 	if err != nil {


### PR DESCRIPTION
Use four upload workers and the maximum Telegram part size for Matrix-to-Telegram media uploads.

The default uploader sends 128 KiB parts sequentially, which makes large uploads latency-bound. I was inspired by Telegram Desktop’s behavior. With this MR, the upload time for a 300 MB file decreased from 4 minutes to 30 seconds on my internet connection.

### Checklist

* [x] I have read and followed the contributing guidelines at <https://docs.mau.fi/bridges/general/contributing.html>
